### PR TITLE
Label banner ads to avoid navigation confusion

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -34,6 +35,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
@@ -44,6 +46,7 @@ import com.d4rk.englishwithlidia.plus.app.lessons.details.ui.LessonActivity
 import com.d4rk.englishwithlidia.plus.app.settings.display.theme.style.Colors
 import com.d4rk.englishwithlidia.plus.app.settings.display.theme.style.TextStyles
 import com.d4rk.englishwithlidia.plus.core.utils.constants.ui.lessons.LessonContentTypes
+import com.d4rk.englishwithlidia.plus.R
 import ir.mahozad.multiplatform.wavyslider.WaveDirection
 import ir.mahozad.multiplatform.wavyslider.material3.WavySlider
 import org.koin.compose.koinInject
@@ -123,21 +126,43 @@ fun LessonContentLayout(
                 }
 
                 LessonContentTypes.AD_BANNER -> {
-                    AdBanner(
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = SizeConstants.MediumSize),
-                        adsConfig = bannerConfig
-                    )
+                            .padding(vertical = SizeConstants.MediumSize)
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.ad_label),
+                            style = TextStyles.label(),
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        AdBanner(
+                            modifier = Modifier.fillMaxWidth(),
+                            adsConfig = bannerConfig
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
                 }
 
                 LessonContentTypes.AD_LARGE_BANNER -> {
-                    AdBanner(
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = SizeConstants.MediumSize),
-                        adsConfig = mediumRectangleConfig
-                    )
+                            .padding(vertical = SizeConstants.MediumSize)
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.ad_label),
+                            style = TextStyles.label(),
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        AdBanner(
+                            modifier = Modifier.fillMaxWidth(),
+                            adsConfig = mediumRectangleConfig
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
                 }
 
                 else -> {

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/components/LessonListLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/components/LessonListLayout.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
@@ -117,23 +118,47 @@ fun LessonItem(lesson : UiHomeLesson,  modifier : Modifier = Modifier) {
         }
 
         LessonConstants.TYPE_AD_VIEW_BANNER -> {
-            AdBanner(
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = SizeConstants.MediumSize),
-                adsConfig = bannerConfig
-            )
+                    .padding(horizontal = 16.dp)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.ad_label),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                AdBanner(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = SizeConstants.MediumSize),
+                    adsConfig = bannerConfig
+                )
+            }
 
             Spacer(modifier = Modifier.height(16.dp))
         }
 
         LessonConstants.TYPE_AD_VIEW_BANNER_LARGE -> {
-            AdBanner(
+            Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = SizeConstants.MediumSize),
-                adsConfig = mediumRectangleConfig
-            )
+                    .padding(horizontal = 16.dp)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.ad_label),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                AdBanner(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = SizeConstants.MediumSize),
+                    adsConfig = mediumRectangleConfig
+                )
+            }
             Spacer(modifier = Modifier.height(16.dp))
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,8 @@
     <string name="find_us">Find us on</string>
     <string name="website">Website</string>
 
+    <string name="ad_label">Advertisement</string>
+
     <string name="question_1">What is English with Lidia Plus?</string>
     <string name="summary_preference_faq_1">English with Lidia Plus is an app that helps you learn English by reading or listening to blog posts written by Lidia, an English teacher.</string>
     <string name="question_2">How can I use the app?</string>


### PR DESCRIPTION
## Summary
- Separate lesson-content banners from navigation by wrapping them in a labeled column with extra spacing.
- Prepend an "Advertisement" label and spacing to banner ads in the lesson list so they are not mistaken for lesson cards.
- Add a reusable `ad_label` string resource for marking ad blocks.

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b4a72a20832db3608a111677245f