### PR TITLE
Use rememberSaveable for lesson audio slider state

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
@@ -28,12 +28,12 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -218,15 +218,11 @@ fun AudioCardView(
         label = "",
     ).value
 
-    var sliderValue by remember { mutableFloatStateOf(0f) }
-    val targetSliderValue by remember(playbackDuration, sliderPosition) {
-        derivedStateOf {
-            if (playbackDuration > 0f) {
-                sliderPosition / playbackDuration
-            } else {
-                0f
-            }
-        }
+    var sliderValue by rememberSaveable { mutableFloatStateOf(0f) }
+    val targetSliderValue = if (playbackDuration > 0f) {
+        sliderPosition / playbackDuration
+    } else {
+        0f
     }
     LaunchedEffect(targetSliderValue) {
         sliderValue = targetSliderValue


### PR DESCRIPTION
## Summary
- persist slider position across configuration changes using `rememberSaveable`
- simplify slider progress calculations in `AudioCardView`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c719d7c618832dae6de9c84d462757