### PR TITLE
Refactor lesson details for immutable UI state

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonRepositoryImpl.kt
@@ -38,24 +38,22 @@ class LessonRepositoryImpl(
                 ?.takeIf { it.data.isNotEmpty() }?.data?.map { networkLesson ->
                     UiLessonScreen(
                         lessonTitle = networkLesson.lessonTitle,
-                        lessonContent = ArrayList(
-                            networkLesson.lessonContent.map { networkContent ->
-                                UiLessonContent(
-                                    contentId = networkContent.contentId,
-                                    contentType = networkContent.contentType,
-                                    contentText = networkContent.contentText,
-                                    contentAudioUrl = networkContent.contentAudioUrl,
-                                    contentImageUrl = networkContent.contentImageUrl,
-                                    contentThumbnailUrl = networkContent.contentThumbnailUrl,
-                                    contentTitle = networkContent.contentTitle,
-                                    contentArtist = networkContent.contentArtist,
-                                    contentAlbumTitle = networkContent.contentAlbumTitle,
-                                    contentGenre = networkContent.contentGenre,
-                                    contentDescription = networkContent.contentDescription,
-                                    contentReleaseYear = networkContent.contentReleaseYear
-                                )
-                            },
-                        ),
+                        lessonContent = networkLesson.lessonContent.map { networkContent ->
+                            UiLessonContent(
+                                contentId = networkContent.contentId,
+                                contentType = networkContent.contentType,
+                                contentText = networkContent.contentText,
+                                contentAudioUrl = networkContent.contentAudioUrl,
+                                contentImageUrl = networkContent.contentImageUrl,
+                                contentThumbnailUrl = networkContent.contentThumbnailUrl,
+                                contentTitle = networkContent.contentTitle,
+                                contentArtist = networkContent.contentArtist,
+                                contentAlbumTitle = networkContent.contentAlbumTitle,
+                                contentGenre = networkContent.contentGenre,
+                                contentDescription = networkContent.contentDescription,
+                                contentReleaseYear = networkContent.contentReleaseYear,
+                            )
+                        },
                     )
                 } ?: emptyList()
             lessons.firstOrNull() ?: UiLessonScreen()

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/model/ui/UiLessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/model/ui/UiLessonScreen.kt
@@ -1,13 +1,17 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 data class UiLessonScreen(
     val isPlaying: Boolean = false,
     val playbackPosition: Long = 0L,
     val playbackDuration: Long = 0L,
     val lessonTitle: String = "",
-    val lessonContent: ArrayList<UiLessonContent> = ArrayList()
+    val lessonContent: List<UiLessonContent> = emptyList(),
 )
 
+@Immutable
 data class UiLessonContent(
     val contentId: String = "",
     val contentType: String = "",
@@ -20,5 +24,5 @@ data class UiLessonContent(
     val contentAlbumTitle: String = "",
     val contentGenre: String = "",
     val contentDescription: String = "",
-    val contentReleaseYear: Int? = null
+    val contentReleaseYear: Int? = null,
 )

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
@@ -7,16 +7,21 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.englishwithlidia.plus.app.player.ActivityPlayer
 import com.d4rk.englishwithlidia.plus.core.utils.constants.ui.lessons.LessonContentTypes
 import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
+import org.koin.core.qualifier.named
 
 class LessonActivity : ActivityPlayer() {
     override val playbackHandler: LessonViewModel by viewModel()
     private val viewModel: LessonViewModel
         get() = playbackHandler
     private var isPlayerPrepared = false
+    private val bannerConfig: AdsConfig by inject()
+    private val mediumRectangleConfig: AdsConfig by inject(named("banner_medium_rectangle"))
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,6 +56,8 @@ class LessonActivity : ActivityPlayer() {
             AppTheme {
                 LessonScreen(
                     viewModel = viewModel,
+                    bannerConfig = bannerConfig,
+                    mediumRectangleConfig = mediumRectangleConfig,
                     onBack = { finish() },
                     onPlayClick = { playPause() },
                     onSeekChange = { newPosition ->

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
@@ -17,6 +18,8 @@ import com.d4rk.englishwithlidia.plus.app.lessons.details.ui.components.LessonCo
 @Composable
 fun LessonScreen(
     viewModel: LessonViewModel,
+    bannerConfig: AdsConfig,
+    mediumRectangleConfig: AdsConfig,
     onBack: () -> Unit,
     onPlayClick: () -> Unit,
     onSeekChange: (Float) -> Unit,
@@ -42,6 +45,8 @@ fun LessonScreen(
                     paddingValues = paddingValues,
                     listState = listState,
                     lesson = lesson,
+                    bannerConfig = bannerConfig,
+                    mediumRectangleConfig = mediumRectangleConfig,
                     onPlayClick = onPlayClick,
                     onSeekChange = onSeekChange,
                 )

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
@@ -53,20 +53,17 @@ import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLess
 import com.d4rk.englishwithlidia.plus.app.settings.display.theme.style.Colors
 import com.d4rk.englishwithlidia.plus.app.settings.display.theme.style.TextStyles
 import com.d4rk.englishwithlidia.plus.core.utils.constants.ui.lessons.LessonContentTypes
-import org.koin.compose.koinInject
-import org.koin.core.qualifier.named
 
 @Composable
 fun LessonContentLayout(
     paddingValues: PaddingValues,
     listState: LazyListState,
     lesson: UiLessonScreen,
+    bannerConfig: AdsConfig,
+    mediumRectangleConfig: AdsConfig,
     onPlayClick: () -> Unit,
     onSeekChange: (Float) -> Unit,
 ) {
-    val bannerConfig: AdsConfig = koinInject()
-    val mediumRectangleConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
-
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()


### PR DESCRIPTION
## Summary
- Mark lesson detail models as `@Immutable` and switch content list to `List`
- Pass ad configs through activity and screen instead of injecting inside composables
- Build repository and UI to use immutable lists for lesson content

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c71d6959cc832d8b40611c46db4df0