### PR TITLE
feat: add wavy progress indicator

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
@@ -7,12 +7,12 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
-import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
 import com.d4rk.englishwithlidia.plus.app.lessons.details.ui.components.LessonContentLayout
+import com.d4rk.englishwithlidia.plus.app.main.ui.components.WavyLoadingScreen
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -35,7 +35,7 @@ fun LessonScreen(
         ScreenStateHandler(
             screenState = screenState,
             onLoading = {
-                LoadingScreen()
+                WavyLoadingScreen()
             },
             onEmpty = {
                 NoDataScreen()

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
-import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
+import com.d4rk.englishwithlidia.plus.app.main.ui.components.WavyLoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.action.HomeEvent
@@ -25,7 +25,7 @@ fun HomeScreen(
     ScreenStateHandler(
         screenState = screenState,
         onLoading = {
-            LoadingScreen()
+            WavyLoadingScreen()
         },
         onEmpty = {
             NoDataScreen(

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/main/ui/components/WavyLoadingScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/main/ui/components/WavyLoadingScreen.kt
@@ -1,0 +1,37 @@
+package com.d4rk.englishwithlidia.plus.app.main.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.LinearWavyProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Stroke
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun WavyLoadingScreen(modifier: Modifier = Modifier) {
+    val strokeWidth = with(LocalDensity.current) { 8.dp.toPx() }
+    val stroke = remember(strokeWidth) { Stroke(width = strokeWidth, cap = StrokeCap.Round) }
+
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        LinearWavyProgressIndicator(
+            modifier = Modifier
+                .fillMaxWidth(0.7f)
+                .height(14.dp),
+            stroke = stroke,
+            trackStroke = stroke,
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary
- add WavyLoadingScreen component using Material 3 expressive LinearWavyProgressIndicator
- show wavy progress indicator during loading on home and lesson screens

## Testing
- `./gradlew test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c71ee908c0832d9ee4a6566c0c1448