### PR TITLE
Use wavy progress indicator for lesson playback

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
@@ -60,9 +60,6 @@ class LessonActivity : ActivityPlayer() {
                     mediumRectangleConfig = mediumRectangleConfig,
                     onBack = { finish() },
                     onPlayClick = { playPause() },
-                    onSeekChange = { newPosition ->
-                        seekTo((newPosition * 1000).toLong())
-                    },
                 )
             }
         }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
@@ -22,7 +22,6 @@ fun LessonScreen(
     mediumRectangleConfig: AdsConfig,
     onBack: () -> Unit,
     onPlayClick: () -> Unit,
-    onSeekChange: (Float) -> Unit,
 ) {
     val listState = rememberLazyListState()
     val screenState: UiStateScreen<UiLessonScreen> by viewModel.uiState.collectAsStateWithLifecycle()
@@ -48,7 +47,6 @@ fun LessonScreen(
                     bannerConfig = bannerConfig,
                     mediumRectangleConfig = mediumRectangleConfig,
                     onPlayClick = onPlayClick,
-                    onSeekChange = onSeekChange,
                 )
             },
         )


### PR DESCRIPTION
## Summary
- replace slider with Material 3 LinearWavyProgressIndicator in lesson audio card
- drop seek callbacks from lesson screen and activity

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c71fb98294832da3f20974a7f375bf