### PR TITLE
Refactor lesson details player preparation

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
@@ -3,14 +3,9 @@ package com.d4rk.englishwithlidia.plus.app.lessons.details.ui
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.englishwithlidia.plus.app.player.ActivityPlayer
-import com.d4rk.englishwithlidia.plus.core.utils.constants.ui.lessons.LessonContentTypes
-import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.qualifier.named
@@ -19,7 +14,6 @@ class LessonActivity : ActivityPlayer() {
     override val playbackHandler: LessonViewModel by viewModel()
     private val viewModel: LessonViewModel
         get() = playbackHandler
-    private var isPlayerPrepared = false
     private val bannerConfig: AdsConfig by inject()
     private val mediumRectangleConfig: AdsConfig by inject(named("banner_medium_rectangle"))
 
@@ -30,28 +24,6 @@ class LessonActivity : ActivityPlayer() {
         val lessonId = intent?.data?.lastPathSegment
         lessonId?.let { viewModel.getLesson(it) }
 
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.uiState.collect { state ->
-                    if (!isPlayerPrepared) {
-                        state.data?.lessonContent?.firstOrNull { it.contentType == LessonContentTypes.CONTENT_PLAYER }?.let { content ->
-                            preparePlayer(
-                                audioUrl = content.contentAudioUrl,
-                                title = content.contentTitle.ifBlank { state.data.lessonTitle },
-                                thumbnailUrl = content.contentThumbnailUrl,
-                                artist = content.contentArtist,
-                                albumTitle = content.contentAlbumTitle,
-                                genre = content.contentGenre,
-                                description = content.contentDescription,
-                                releaseYear = content.contentReleaseYear
-                            )
-                            isPlayerPrepared = true
-                        }
-                    }
-                }
-            }
-        }
-
         setContent {
             AppTheme {
                 LessonScreen(
@@ -60,6 +32,18 @@ class LessonActivity : ActivityPlayer() {
                     mediumRectangleConfig = mediumRectangleConfig,
                     onBack = { finish() },
                     onPlayClick = { playPause() },
+                    onPreparePlayer = { content, lessonTitle ->
+                        preparePlayer(
+                            audioUrl = content.contentAudioUrl,
+                            title = content.contentTitle.ifBlank { lessonTitle },
+                            thumbnailUrl = content.contentThumbnailUrl,
+                            artist = content.contentArtist,
+                            albumTitle = content.contentAlbumTitle,
+                            genre = content.contentGenre,
+                            description = content.contentDescription,
+                            releaseYear = content.contentReleaseYear
+                        )
+                    },
                 )
             }
         }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
@@ -3,7 +3,11 @@ package com.d4rk.englishwithlidia.plus.app.lessons.details.ui
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
@@ -11,7 +15,9 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonContent
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
+import com.d4rk.englishwithlidia.plus.core.utils.constants.ui.lessons.LessonContentTypes
 import com.d4rk.englishwithlidia.plus.app.lessons.details.ui.components.LessonContentLayout
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -22,9 +28,19 @@ fun LessonScreen(
     mediumRectangleConfig: AdsConfig,
     onBack: () -> Unit,
     onPlayClick: () -> Unit,
+    onPreparePlayer: (UiLessonContent, String) -> Unit,
 ) {
     val listState = rememberLazyListState()
     val screenState: UiStateScreen<UiLessonScreen> by viewModel.uiState.collectAsStateWithLifecycle()
+    var isPlayerPrepared by remember { mutableStateOf(false) }
+
+    LaunchedEffect(screenState.data?.lessonContent) {
+        val content = screenState.data?.lessonContent?.firstOrNull { it.contentType == LessonContentTypes.CONTENT_PLAYER }
+        if (!isPlayerPrepared && content != null) {
+            onPreparePlayer(content, screenState.data.lessonTitle)
+            isPlayerPrepared = true
+        }
+    }
 
     LargeTopAppBarWithScaffold(
         title = screenState.data?.lessonTitle ?: "",


### PR DESCRIPTION
## Summary
- handle lesson player preparation inside composable using lifecycle-aware LaunchedEffect
- simplify LessonActivity by delegating playback setup through a callback

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c720efd62c832d9cf1413128ba0c25