### PR TITLE
refactor: extract lesson mapper for SOLID compliance

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonMapper.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonMapper.kt
@@ -1,0 +1,32 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.details.data
+
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonContent
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
+import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiLessonResponse
+
+class LessonMapper {
+    fun map(response: ApiLessonResponse): List<UiLessonScreen> {
+        return response.data.map { networkLesson ->
+            UiLessonScreen(
+                lessonTitle = networkLesson.lessonTitle,
+                lessonContent = networkLesson.lessonContent.map { networkContent ->
+                    UiLessonContent(
+                        contentId = networkContent.contentId,
+                        contentType = networkContent.contentType,
+                        contentText = networkContent.contentText,
+                        contentAudioUrl = networkContent.contentAudioUrl,
+                        contentImageUrl = networkContent.contentImageUrl,
+                        contentThumbnailUrl = networkContent.contentThumbnailUrl,
+                        contentTitle = networkContent.contentTitle,
+                        contentArtist = networkContent.contentArtist,
+                        contentAlbumTitle = networkContent.contentAlbumTitle,
+                        contentGenre = networkContent.contentGenre,
+                        contentDescription = networkContent.contentDescription,
+                        contentReleaseYear = networkContent.contentReleaseYear,
+                    )
+                },
+            )
+        }
+    }
+}
+

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AppModule.kt
@@ -6,6 +6,7 @@ import com.d4rk.android.libs.apptoolkit.app.onboarding.utils.interfaces.provider
 import com.d4rk.android.libs.apptoolkit.data.client.KtorClient
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
 import com.d4rk.englishwithlidia.plus.BuildConfig
+import com.d4rk.englishwithlidia.plus.app.lessons.details.data.LessonMapper
 import com.d4rk.englishwithlidia.plus.app.lessons.details.data.LessonRepositoryImpl
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.repository.LessonRepository
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.usecases.GetLessonUseCase
@@ -40,7 +41,8 @@ val appModule : Module = module {
     factory { GetHomeLessonsUseCase(repository = get()) }
     viewModel { HomeViewModel(getHomeLessonsUseCase = get(), dispatcherProvider = get()) }
 
-    single<LessonRepository> { LessonRepositoryImpl(client = get(), dispatchers = get()) }
+    single { LessonMapper() }
+    single<LessonRepository> { LessonRepositoryImpl(client = get(), dispatchers = get(), mapper = get()) }
     factory { GetLessonUseCase(repository = get()) }
     viewModel { LessonViewModel(getLessonUseCase = get()) }
 }


### PR DESCRIPTION
## Summary
- refactor LessonRepositoryImpl to delegate response conversion to a dedicated mapper
- register LessonMapper in DI container

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c721db2c30832d873831335e398cd1