### PR TITLE
Improve performance for lessons list

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/components/LessonListLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/components/LessonListLayout.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -56,7 +57,10 @@ fun LessonListLayout(
         verticalArrangement = Arrangement.spacedBy(SizeConstants.LargeSize),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        itemsIndexed(lessons) { index, lesson ->
+        itemsIndexed(
+            items = lessons,
+            key = { _, lesson -> lesson.lessonId },
+        ) { index, lesson ->
             LessonItem(
                 lesson = lesson,
                 modifier = Modifier
@@ -133,13 +137,15 @@ fun LessonItem(lesson: UiHomeLesson, modifier: Modifier = Modifier) {
         }
 
         LessonConstants.TYPE_FULL_IMAGE_BANNER -> {
+            val onLessonClick = remember(context, lesson) {
+                { openLessonDetailActivity(context = context, lesson = lesson) }
+            }
             LessonCard(
                 title = lesson.lessonTitle,
                 imageResource = lesson.lessonThumbnailImageUrl,
-                onClick = {
-                    openLessonDetailActivity(context = context, lesson = lesson)
-                },
-                modifier = modifier)
+                onClick = onLessonClick,
+                modifier = modifier,
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- add stable keys for lazy lesson list items
- remember lesson click handler to avoid lambda recreation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73445e314832daf4fab7428626d02