### PR TITLE
Use lifecycle-aware state and immutable lesson models

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -127,4 +127,5 @@ dependencies {
     implementation(dependencyNotation = libs.media3.exoplayer)
     implementation(dependencyNotation = libs.media3.ui)
     implementation(dependencyNotation = libs.media3.session)
+    implementation(libs.lifecycle.runtime.compose)
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeRepositoryImpl.kt
@@ -40,7 +40,7 @@ class HomeRepositoryImpl(
                     )
                 } ?: emptyList()
 
-            UiHomeScreen(lessons = ArrayList(lessons))
+            UiHomeScreen(lessons = lessons)
         }.getOrElse {
             UiHomeScreen()
         }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/model/ui/UiHomeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/model/ui/UiHomeScreen.kt
@@ -1,13 +1,13 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui
 
 data class UiHomeScreen(
-    val lessons : ArrayList<UiHomeLesson> = ArrayList()
+    val lessons: List<UiHomeLesson> = emptyList(),
 )
 
 data class UiHomeLesson(
-    val lessonId : String = "" ,
-    val lessonTitle : String = "" ,
-    val lessonType : String = "" ,
-    var lessonThumbnailImageUrl : String = "" ,
-    val lessonDeepLinkPath : String = "" ,
+    val lessonId: String = "",
+    val lessonTitle: String = "",
+    val lessonType: String = "",
+    val lessonThumbnailImageUrl: String = "",
+    val lessonDeepLinkPath: String = "",
 )

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeScreen.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.WifiTetheringError
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
@@ -20,7 +20,7 @@ fun HomeScreen(
     paddingValues : PaddingValues
 ) {
     val viewModel : HomeViewModel = koinViewModel()
-    val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsState()
+    val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsStateWithLifecycle()
 
     ScreenStateHandler(
         screenState = screenState,
@@ -35,7 +35,7 @@ fun HomeScreen(
             })
         },
         onSuccess = { uiHomeScreen ->
-            LessonListLayout(lessons = uiHomeScreen.lessons,paddingValues)
+            LessonListLayout(lessons = uiHomeScreen.lessons, paddingValues)
         },
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,11 +5,13 @@ kotlin = "2.2.20"
 google-services = "4.4.3"
 google-firebase-crashlytics = "3.0.6"
 media3 = "1.8.0"
+lifecycle-runtime-compose = "2.8.7"
 
 [libraries]
 media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
 media3-ui = { module = "androidx.media3:media3-ui", version.ref = "media3" }
 media3-session = { module = "androidx.media3:media3-session", version.ref = "media3" }
+lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle-runtime-compose" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- switch HomeScreen to collect state with `collectAsStateWithLifecycle`
- make lesson UI models immutable and drop `ArrayList` usage
- add lifecycle-runtime-compose dependency

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c735a01cf0832d9eeb102acd0f74e7