### PR TITLE
Refactor lessons list composables

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeScreen.kt
@@ -1,10 +1,9 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.list.ui
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.WifiTetheringError
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
@@ -13,29 +12,48 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHa
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.action.HomeEvent
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
 import com.d4rk.englishwithlidia.plus.app.lessons.list.ui.components.LessonListLayout
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.WifiTetheringError
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
-fun HomeScreen(
-    paddingValues : PaddingValues
+fun HomeRoute(
+    paddingValues: PaddingValues,
+    viewModel: HomeViewModel = koinViewModel(),
 ) {
-    val viewModel : HomeViewModel = koinViewModel()
     val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsStateWithLifecycle()
 
+    HomeScreen(
+        screenState = screenState,
+        onRetry = { viewModel.onEvent(event = HomeEvent.FetchLessons) },
+        paddingValues = paddingValues,
+    )
+}
+
+
+@Composable
+fun HomeScreen(
+    screenState: UiStateScreen<UiHomeScreen>,
+    onRetry: () -> Unit,
+    paddingValues: PaddingValues,
+    modifier: Modifier = Modifier,
+) {
     ScreenStateHandler(
         screenState = screenState,
-        onLoading = {
-            LoadingScreen()
-        },
+        onLoading = { LoadingScreen() },
         onEmpty = {
             NoDataScreen(
                 icon = Icons.Outlined.WifiTetheringError,
-                showRetry = true, onRetry = {
-                viewModel.onEvent(event = HomeEvent.FetchLessons)
-            })
+                showRetry = true,
+                onRetry = onRetry,
+            )
         },
         onSuccess = { uiHomeScreen ->
-            LessonListLayout(lessons = uiHomeScreen.lessons, paddingValues)
+            LessonListLayout(
+                lessons = uiHomeScreen.lessons,
+                paddingValues = paddingValues,
+                modifier = modifier,
+            )
         },
     )
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/components/LessonListLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/components/LessonListLayout.kt
@@ -49,6 +49,7 @@ import org.koin.core.qualifier.named
 fun LessonListLayout(
     lessons: List<UiHomeLesson>,
     paddingValues: PaddingValues,
+    modifier: Modifier = Modifier,
 ) {
     // Obtain ad configurations once for the entire list
     val bannerConfig: AdsConfig = koinInject()
@@ -56,7 +57,7 @@ fun LessonListLayout(
         koinInject(qualifier = named(name = "banner_medium_rectangle"))
 
     LazyColumn(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .padding(paddingValues),
         contentPadding = PaddingValues(horizontal = SizeConstants.LargeSize),
@@ -78,6 +79,7 @@ fun LessonListLayout(
         }
     }
 }
+
 
 
 @Composable
@@ -141,23 +143,23 @@ private fun LessonActionButtonsRow(modifier: Modifier = Modifier) {
             .padding(start = 24.dp, end = 24.dp),
     ) {
         OutlinedUrlButtons(
-            vectorIcon = Icons.Outlined.Language,
+            url = "https://sites.google.com/view/englishwithlidia",
+            text = R.string.website,
             modifier = Modifier
                 .weight(1f)
                 .bounceClick(),
-            text = R.string.website,
-            url = "https://sites.google.com/view/englishwithlidia",
+            vectorIcon = Icons.Outlined.Language,
         )
 
         Spacer(modifier = Modifier.width(24.dp))
 
         OutlinedUrlButtons(
-            painterIcon = painterResource(id = R.drawable.ic_find_us),
+            url = "https://www.facebook.com/lidia.melinte",
+            text = R.string.find_us,
             modifier = Modifier
                 .weight(1f)
                 .bounceClick(),
-            text = R.string.find_us,
-            url = "https://www.facebook.com/lidia.melinte",
+            painterIcon = painterResource(id = R.drawable.ic_find_us),
         )
     }
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/components/OutlinedUrlButtons.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/components/OutlinedUrlButtons.kt
@@ -17,35 +17,33 @@ import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 
 @Composable
 fun OutlinedUrlButtons(
-    url : String ,
-    vectorIcon : ImageVector? = null ,
-    painterIcon : Painter? = null ,
-    text : Int ,
-    modifier : Modifier
+    url: String,
+    text: Int,
+    modifier: Modifier = Modifier,
+    vectorIcon: ImageVector? = null,
+    painterIcon: Painter? = null,
 ) {
     val context = LocalContext.current
-    OutlinedButton(onClick = {
-        IntentsHelper.openUrl(
-            context = context , url = url
-        )
-    } , modifier = modifier) {
 
+    OutlinedButton(
+        onClick = { IntentsHelper.openUrl(context = context, url = url) },
+        modifier = modifier,
+    ) {
         if (painterIcon != null) {
             Icon(
-                painter = painterIcon ,
-                contentDescription = null ,
-                modifier = Modifier.size(ButtonDefaults.IconSize)
+                painter = painterIcon,
+                contentDescription = null,
+                modifier = Modifier.size(ButtonDefaults.IconSize),
             )
-        }
-        else if (vectorIcon != null) {
+        } else if (vectorIcon != null) {
             Icon(
-                imageVector = vectorIcon ,
-                contentDescription = null ,
-                modifier = Modifier.size(ButtonDefaults.IconSize)
+                imageVector = vectorIcon,
+                contentDescription = null,
+                modifier = Modifier.size(ButtonDefaults.IconSize),
             )
         }
 
         Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-        Text(text = stringResource(id = text) , modifier = Modifier.basicMarquee())
+        Text(text = stringResource(id = text), modifier = Modifier.basicMarquee())
     }
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/main/ui/components/navigation/AppNavigationHost.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/main/ui/components/navigation/AppNavigationHost.kt
@@ -12,7 +12,7 @@ import com.d4rk.android.libs.apptoolkit.app.main.utils.constants.NavigationDrawe
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.SettingsActivity
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
-import com.d4rk.englishwithlidia.plus.app.lessons.list.ui.HomeScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.list.ui.HomeRoute
 import com.d4rk.englishwithlidia.plus.app.main.utils.constants.NavigationRoutes
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -25,7 +25,7 @@ fun AppNavigationHost(
         navController = navController , startDestination = NavigationRoutes.ROUTE_LESSONS_LIST
     ) {
         composable(route = NavigationRoutes.ROUTE_LESSONS_LIST) {
-            HomeScreen(paddingValues = paddingValues)
+            HomeRoute(paddingValues = paddingValues)
         }
     }
 }


### PR DESCRIPTION
## Summary
- split stateful HomeRoute from stateless HomeScreen with modifier support
- allow LessonListLayout and OutlinedUrlButtons to accept modifier for better composition
- update navigation host to use new HomeRoute

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7393afe54832db92ba67411ce448f