### PR TITLE
refactor: separate domain and ui models for lessons list

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeRepositoryImpl.kt
@@ -2,8 +2,8 @@ package com.d4rk.englishwithlidia.plus.app.lessons.list.data
 
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.englishwithlidia.plus.BuildConfig
-import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeLesson
-import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeLesson
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.repository.HomeRepository
 import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiHomeResponse
 import com.d4rk.englishwithlidia.plus.core.utils.constants.api.ApiConstants
@@ -32,13 +32,13 @@ class HomeRepositoryImpl(
         isLenient = true
     }
 
-    override fun getHomeLessons(): Flow<UiHomeScreen> =
+    override fun getHomeLessons(): Flow<HomeScreen> =
         flow {
             val jsonString = client.get(baseUrl).bodyAsText()
             val lessons = jsonString.takeUnless { it.isBlank() }
                 ?.let { jsonParser.decodeFromString<ApiHomeResponse>(it) }
                 ?.takeIf { it.data.isNotEmpty() }?.data?.map { networkLesson ->
-                    UiHomeLesson(
+                    HomeLesson(
                         lessonId = networkLesson.lessonId,
                         lessonTitle = networkLesson.lessonTitle,
                         lessonType = networkLesson.lessonType,
@@ -47,9 +47,9 @@ class HomeRepositoryImpl(
                     )
                 } ?: emptyList()
 
-            emit(UiHomeScreen(lessons = lessons))
+            emit(HomeScreen(lessons = lessons))
         }.catch { throwable ->
             if (throwable is CancellationException) throw throwable
-            emit(UiHomeScreen())
+            emit(HomeScreen())
         }.flowOn(dispatchers.io)
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/model/HomeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/model/HomeScreen.kt
@@ -1,0 +1,19 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model
+
+/**
+ * Domain representation of the home lessons screen.
+ */
+data class HomeScreen(
+    val lessons: List<HomeLesson> = emptyList(),
+)
+
+/**
+ * Domain representation of a single lesson item.
+ */
+data class HomeLesson(
+    val lessonId: String = "",
+    val lessonTitle: String = "",
+    val lessonType: String = "",
+    val lessonThumbnailImageUrl: String = "",
+    val lessonDeepLinkPath: String = "",
+)

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/repository/HomeRepository.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/repository/HomeRepository.kt
@@ -1,8 +1,8 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.list.domain.repository
 
-import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
 import kotlinx.coroutines.flow.Flow
 
 interface HomeRepository {
-    fun getHomeLessons(): Flow<UiHomeScreen>
+    fun getHomeLessons(): Flow<HomeScreen>
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/usecases/GetHomeLessonsUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/usecases/GetHomeLessonsUseCase.kt
@@ -1,11 +1,11 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.list.domain.usecases
 
-import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.repository.HomeRepository
 import kotlinx.coroutines.flow.Flow
 
 class GetHomeLessonsUseCase(private val repository: HomeRepository) {
-    operator fun invoke(): Flow<UiHomeScreen> {
+    operator fun invoke(): Flow<HomeScreen> {
         return repository.getHomeLessons()
     }
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModel.kt
@@ -6,6 +6,9 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.action.HomeAction
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.action.HomeEvent
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeLesson
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeLesson
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.usecases.GetHomeLessonsUseCase
 import kotlinx.coroutines.CancellationException
@@ -38,17 +41,30 @@ class HomeViewModel(
                         current.copy(screenState = ScreenState.NoData(), data = UiHomeScreen())
                     }
                 }
-                .collect { lessons ->
-                    if (lessons.lessons.isEmpty()) {
+                .collect { homeScreen ->
+                    val uiScreen = homeScreen.toUi()
+                    if (uiScreen.lessons.isEmpty()) {
                         screenState.update { current ->
-                            current.copy(screenState = ScreenState.NoData(), data = lessons)
+                            current.copy(screenState = ScreenState.NoData(), data = UiHomeScreen())
                         }
                     } else {
                         screenState.update { current ->
-                            current.copy(screenState = ScreenState.Success(), data = lessons)
+                            current.copy(screenState = ScreenState.Success(), data = uiScreen)
                         }
                     }
                 }
         }
     }
 }
+
+private fun HomeScreen.toUi(): UiHomeScreen =
+    UiHomeScreen(lessons = lessons.map { it.toUi() })
+
+private fun HomeLesson.toUi(): UiHomeLesson =
+    UiHomeLesson(
+        lessonId = lessonId,
+        lessonTitle = lessonTitle,
+        lessonType = lessonType,
+        lessonThumbnailImageUrl = lessonThumbnailImageUrl,
+        lessonDeepLinkPath = lessonDeepLinkPath,
+    )


### PR DESCRIPTION
## Summary
- add dedicated domain models for home lessons
- refactor repository and use case to expose domain models
- map domain models to UI state within HomeViewModel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73d27da18832db460e2fab3cdc9f2