### PR TITLE
refactor lessons list with dedicated mappers

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeMapper.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeMapper.kt
@@ -1,0 +1,24 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.list.data
+
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeLesson
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
+import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiHomeResponse
+
+/**
+ * Maps network responses into domain models for the home lessons screen.
+ */
+class HomeMapper {
+    fun map(response: ApiHomeResponse): HomeScreen {
+        val lessons = response.data.map { networkLesson ->
+            HomeLesson(
+                lessonId = networkLesson.lessonId,
+                lessonTitle = networkLesson.lessonTitle,
+                lessonType = networkLesson.lessonType,
+                lessonThumbnailImageUrl = networkLesson.lessonThumbnailImageUrl,
+                lessonDeepLinkPath = networkLesson.lessonDeepLinkPath,
+            )
+        }
+        return HomeScreen(lessons = lessons)
+    }
+}
+

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/mapper/HomeUiMapper.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/mapper/HomeUiMapper.kt
@@ -1,0 +1,24 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.list.domain.mapper
+
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeLesson
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeLesson
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
+
+/**
+ * Converts domain models into UI models for the home lessons screen.
+ */
+class HomeUiMapper {
+    fun map(screen: HomeScreen): UiHomeScreen =
+        UiHomeScreen(lessons = screen.lessons.map(::mapLesson))
+
+    private fun mapLesson(lesson: HomeLesson): UiHomeLesson =
+        UiHomeLesson(
+            lessonId = lesson.lessonId,
+            lessonTitle = lesson.lessonTitle,
+            lessonType = lesson.lessonType,
+            lessonThumbnailImageUrl = lesson.lessonThumbnailImageUrl,
+            lessonDeepLinkPath = lesson.lessonDeepLinkPath,
+        )
+}
+

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModel.kt
@@ -6,10 +6,9 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.action.HomeAction
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.action.HomeEvent
-import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeLesson
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
-import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeLesson
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.mapper.HomeUiMapper
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.usecases.GetHomeLessonsUseCase
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.catch
@@ -18,6 +17,7 @@ import kotlinx.coroutines.launch
 
 class HomeViewModel(
     private val getHomeLessonsUseCase: GetHomeLessonsUseCase,
+    private val uiMapper: HomeUiMapper,
 ) : ScreenViewModel<UiHomeScreen, HomeEvent, HomeAction>(
     initialState = UiStateScreen(screenState = ScreenState.IsLoading(), data = UiHomeScreen())
 ) {
@@ -42,7 +42,7 @@ class HomeViewModel(
                     }
                 }
                 .collect { homeScreen ->
-                    val uiScreen = homeScreen.toUi()
+                    val uiScreen = uiMapper.map(homeScreen)
                     if (uiScreen.lessons.isEmpty()) {
                         screenState.update { current ->
                             current.copy(screenState = ScreenState.NoData(), data = UiHomeScreen())
@@ -56,15 +56,3 @@ class HomeViewModel(
         }
     }
 }
-
-private fun HomeScreen.toUi(): UiHomeScreen =
-    UiHomeScreen(lessons = lessons.map { it.toUi() })
-
-private fun HomeLesson.toUi(): UiHomeLesson =
-    UiHomeLesson(
-        lessonId = lessonId,
-        lessonTitle = lessonTitle,
-        lessonType = lessonType,
-        lessonThumbnailImageUrl = lessonThumbnailImageUrl,
-        lessonDeepLinkPath = lessonDeepLinkPath,
-    )

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AppModule.kt
@@ -12,7 +12,9 @@ import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.repository.Less
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.usecases.GetLessonUseCase
 import com.d4rk.englishwithlidia.plus.app.lessons.details.ui.LessonViewModel
 import com.d4rk.englishwithlidia.plus.app.lessons.list.data.HomeRepositoryImpl
+import com.d4rk.englishwithlidia.plus.app.lessons.list.data.HomeMapper
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.repository.HomeRepository
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.mapper.HomeUiMapper
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.usecases.GetHomeLessonsUseCase
 import com.d4rk.englishwithlidia.plus.app.lessons.list.ui.HomeViewModel
 import com.d4rk.englishwithlidia.plus.app.main.ui.MainViewModel
@@ -37,9 +39,11 @@ val appModule : Module = module {
     //single<String>(qualifier = named(name = "developer_apps_base_url")) { BuildConfig.DEVELOPER_APPS_BASE_URL } // TODO: Make the API link in gradle
 
     // Lessons
-    single<HomeRepository> { HomeRepositoryImpl(client = get(), dispatchers = get()) }
+    single { HomeMapper() }
+    single<HomeRepository> { HomeRepositoryImpl(client = get(), dispatchers = get(), mapper = get()) }
     factory { GetHomeLessonsUseCase(repository = get()) }
-    viewModel { HomeViewModel(getHomeLessonsUseCase = get()) }
+    single { HomeUiMapper() }
+    viewModel { HomeViewModel(getHomeLessonsUseCase = get(), uiMapper = get()) }
 
     single { LessonMapper() }
     single { AudioCacheManager(context = get(), dispatchers = get()) }


### PR DESCRIPTION
## Summary
- add HomeMapper to convert network responses into domain models
- introduce HomeUiMapper and use it in HomeViewModel
- wire new mappers through Koin dependencies

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73e2b6f88832d8546f6f7a9594ed6