### PR TITLE
Add HomeViewModel tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -157,4 +157,7 @@ dependencies {
     implementation(dependencyNotation = libs.media3.exoplayer)
     implementation(dependencyNotation = libs.media3.ui)
     implementation(dependencyNotation = libs.media3.session)
+
+    testImplementation(dependencyNotation = "junit:junit:4.13.2")
+    testImplementation(dependencyNotation = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
 }

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
@@ -1,0 +1,80 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.list.ui
+
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeLesson
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.repository.HomeRepository
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.usecases.GetHomeLessonsUseCase
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.mapper.HomeUiMapper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `state is loading while lessons are fetched`() = runTest {
+        val flow = MutableSharedFlow<HomeScreen>()
+        val useCase = GetHomeLessonsUseCase(FakeHomeRepository(flow))
+        val viewModel = HomeViewModel(useCase, HomeUiMapper())
+
+        assertTrue(viewModel.uiState.value.screenState is ScreenState.IsLoading)
+    }
+
+    @Test
+    fun `state is success when lessons available`() = runTest {
+        val lesson = HomeLesson(lessonId = "1", lessonTitle = "Title", lessonType = "video", lessonThumbnailImageUrl = "", lessonDeepLinkPath = "")
+        val flow = flowOf(HomeScreen(lessons = listOf(lesson)))
+        val useCase = GetHomeLessonsUseCase(FakeHomeRepository(flow))
+        val viewModel = HomeViewModel(useCase, HomeUiMapper())
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.screenState is ScreenState.Success)
+        assertEquals(1, state.data.lessons.size)
+    }
+
+    @Test
+    fun `state is no data when lessons list is empty`() = runTest {
+        val flow = flowOf(HomeScreen())
+        val useCase = GetHomeLessonsUseCase(FakeHomeRepository(flow))
+        val viewModel = HomeViewModel(useCase, HomeUiMapper())
+
+        advanceUntilIdle()
+
+        assertTrue(viewModel.uiState.value.screenState is ScreenState.NoData)
+    }
+
+    private class FakeHomeRepository(
+        private val flow: Flow<HomeScreen>
+    ) : HomeRepository {
+        override fun getHomeLessons(): Flow<HomeScreen> = flow
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit tests for HomeViewModel covering loading, success and empty states
- include JUnit and coroutine-test dependencies

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c746eefd00832dbb19b48a5e7092bf