### PR TITLE
test: verify use case repository call

### DIFF
--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/usecases/GetHomeLessonsUseCaseTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/domain/usecases/GetHomeLessonsUseCaseTest.kt
@@ -1,0 +1,25 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.list.domain.usecases
+
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.repository.HomeRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+
+class GetHomeLessonsUseCaseTest {
+
+    private val repository: HomeRepository = mockk()
+    private val useCase = GetHomeLessonsUseCase(repository)
+
+    @Test
+    fun `invoke calls repository once`() {
+        every { repository.getHomeLessons() } returns flowOf(HomeScreen())
+
+        useCase()
+
+        verify(exactly = 1) { repository.getHomeLessons() }
+    }
+}
+


### PR DESCRIPTION
## Summary
- test that GetHomeLessonsUseCase invokes HomeRepository.getHomeLessons exactly once

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cbf9da9c832d9874f8d593651d5c