### PR TITLE
Use MutableSharedFlow for sequential HomeViewModel states

### DIFF
--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
@@ -49,11 +49,19 @@ class HomeViewModelTest {
 
     @Test
     fun `state is success when lessons available`() = runTest {
-        val lesson = HomeLesson(lessonId = "1", lessonTitle = "Title", lessonType = "video", lessonThumbnailImageUrl = "", lessonDeepLinkPath = "")
-        val flow = flowOf(HomeScreen(lessons = listOf(lesson)))
+        val lesson = HomeLesson(
+            lessonId = "1",
+            lessonTitle = "Title",
+            lessonType = "video",
+            lessonThumbnailImageUrl = "",
+            lessonDeepLinkPath = "",
+        )
+        val flow = MutableSharedFlow<HomeScreen>()
         val useCase = GetHomeLessonsUseCase(FakeHomeRepository(flow))
         val viewModel = HomeViewModel(useCase, HomeUiMapper())
 
+        flow.emit(HomeScreen())
+        flow.emit(HomeScreen(lessons = listOf(lesson)))
         advanceUntilIdle()
 
         val state = viewModel.uiState.value


### PR DESCRIPTION
## Summary
- Test HomeViewModel with MutableSharedFlow emitting empty then filled screens

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cbf87ef0832da34ccc9996dd01c3