### PR TITLE
test: verify HomeViewModel handles repository errors

### DIFF
--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
@@ -85,7 +85,9 @@ class HomeViewModelTest {
 
         val state = viewModel.uiState.value
         assertTrue(state.screenState is ScreenState.NoData)
-        assertTrue(state.data.lessons.isEmpty())
+        val data = state.data
+        assertNotNull(data)
+        assertTrue(data!!.lessons.isEmpty())
     }
 
     private class FakeHomeRepository(

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -72,6 +73,19 @@ class HomeViewModelTest {
         advanceUntilIdle()
 
         assertTrue(viewModel.uiState.value.screenState is ScreenState.NoData)
+    }
+
+    @Test
+    fun `state is no data when lessons fetch fails`() = runTest {
+        val flow: Flow<HomeScreen> = flow { throw RuntimeException() }
+        val useCase = GetHomeLessonsUseCase(FakeHomeRepository(flow))
+        val viewModel = HomeViewModel(useCase, HomeUiMapper())
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.screenState is ScreenState.NoData)
+        assertTrue(state.data.lessons.isEmpty())
     }
 
     private class FakeHomeRepository(


### PR DESCRIPTION
## Summary
- add failing flow test for HomeViewModel

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies of task ':app:testDebugUnitTest'. Failed to install the following Android SDK packages as some licences have not been accepted.)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cbf5fd14832db76a61aecba1d851