### PR TITLE
feat: enable wavy progress seek

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
@@ -44,6 +44,7 @@ class LessonActivity : ActivityPlayer() {
                             releaseYear = content.contentReleaseYear
                         )
                     },
+                    onSeek = { position -> seekTo((position * 1000).toLong()) },
                 )
             }
         }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
@@ -29,6 +29,7 @@ fun LessonScreen(
     onBack: () -> Unit,
     onPlayClick: () -> Unit,
     onPreparePlayer: (UiLessonContent, String) -> Unit,
+    onSeek: (Float) -> Unit,
 ) {
     val listState = rememberLazyListState()
     val screenState: UiStateScreen<UiLessonScreen> by viewModel.uiState.collectAsStateWithLifecycle()
@@ -66,6 +67,7 @@ fun LessonScreen(
                     bannerConfig = bannerConfig,
                     mediumRectangleConfig = mediumRectangleConfig,
                     onPlayClick = onPlayClick,
+                    onSeek = onSeek,
                 )
             },
         )

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
@@ -101,6 +101,11 @@ abstract class ActivityPlayer : AppCompatActivity() {
         }
     }
 
+    fun seekTo(positionMs: Long) {
+        player?.seekTo(positionMs)
+        playbackHandler.updatePlaybackPosition(positionMs)
+    }
+
     private fun startPositionUpdates() {
         positionJob?.cancel()
         positionJob = lifecycleScope.launch(Dispatchers.Default) {


### PR DESCRIPTION
## Summary
- make AudioCardView's wavy progress interactive with draggable handle
- plumb seek callback through lesson screen and activity
- add seekTo support in ActivityPlayer

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d0ef4248832d9bf0ede8b16bdacd