### PR TITLE
Add unit test for failed home lessons fetch

### DIFF
--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -80,6 +81,21 @@ class HomeViewModelTest {
         advanceUntilIdle()
 
         assertTrue(viewModel.uiState.value.screenState is ScreenState.NoData)
+    }
+
+    @Test
+    fun `state is no data when lessons fetch fails`() = runTest {
+        val flow: Flow<HomeScreen> = flow { throw RuntimeException() }
+        val useCase = GetHomeLessonsUseCase(FakeHomeRepository(flow))
+        val viewModel = HomeViewModel(useCase, HomeUiMapper())
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.screenState is ScreenState.NoData)
+        val data = state.data
+        assertNotNull(data)
+        assertTrue(data!!.lessons.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Summary
- cover failure scenario for home lesson fetching by ensuring screen shows NoData and empty list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d2b0f5e0832db0e05ecea4269eac