### PR TITLE
Handle Errors enum cases with user messages

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/utils/extensions/Errors.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/utils/extensions/Errors.kt
@@ -1,8 +1,8 @@
 package com.d4rk.englishwithlidia.plus.core.utils.extensions
 
 import android.database.sqlite.SQLiteException
-import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.d4rk.englishwithlidia.plus.R
 import com.d4rk.englishwithlidia.plus.core.domain.model.network.Errors
 import kotlinx.serialization.SerializationException
 import java.net.ConnectException
@@ -13,8 +13,19 @@ import java.sql.SQLException
 fun Errors.asUiText(): UiTextHelper {
     return when (this) {
         // Network errors
-        else -> UiTextHelper.StringResource(R.string.unknown_error)
+        Errors.Network.NO_INTERNET -> UiTextHelper.StringResource(R.string.error_no_internet)
+        Errors.Network.REQUEST_TIMEOUT -> UiTextHelper.StringResource(R.string.error_request_timeout)
+        Errors.Network.SERIALIZATION -> UiTextHelper.StringResource(R.string.error_serialization)
 
+        // UseCase errors
+        Errors.UseCase.NO_DATA -> UiTextHelper.StringResource(R.string.error_no_data)
+        Errors.UseCase.FAILED_TO_LOAD_APPS -> UiTextHelper.StringResource(R.string.error_failed_to_load_apps)
+        Errors.UseCase.ILLEGAL_ARGUMENT -> UiTextHelper.StringResource(R.string.error_illegal_argument)
+
+        // Database errors
+        Errors.Database.DATABASE_OPERATION_FAILED -> UiTextHelper.StringResource(R.string.error_database_operation_failed)
+
+        else -> UiTextHelper.StringResource(R.string.unknown_error)
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,4 +23,13 @@
     <string name="summary_preference_faq_8">The app is updated regularly with new lessons and features. You can check the Google Play page for the latest updates or follow D4rK on social media for announcements.</string>
     <string name="question_9">Who is Lidia Melinte and what is her role in the app?</string>
     <string name="summary_preference_faq_9">Lidia Melinte, an English teacher, creates the lessons and narrates the audios in the app.</string>
+
+    <string name="error_request_timeout">The request timed out. Please try again.</string>
+    <string name="error_no_internet">No internet connection. Please check your connection and try again.</string>
+    <string name="error_serialization">Data parsing error. Please try again.</string>
+    <string name="error_no_data">No data available.</string>
+    <string name="error_failed_to_load_apps">Failed to load apps.</string>
+    <string name="error_illegal_argument">Invalid input provided.</string>
+    <string name="error_database_operation_failed">Database operation failed.</string>
+    <string name="unknown_error">An unknown error occurred.</string>
 </resources>


### PR DESCRIPTION
## Summary
- map Errors enums to user-friendly UiTextHelper messages
- add string resources for new error cases

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e4958444832db5ed201394f37773