### PR TITLE
Handle playback errors in lesson player

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/model/ui/UiLessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/model/ui/UiLessonScreen.kt
@@ -7,6 +7,7 @@ data class UiLessonScreen(
     val isPlaying: Boolean = false,
     val playbackPosition: Long = 0L,
     val playbackDuration: Long = 0L,
+    val hasPlaybackError: Boolean = false,
     val lessonTitle: String = "",
     val lessonContent: List<UiLessonContent> = emptyList(),
 )

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
@@ -63,4 +63,8 @@ class LessonViewModel(
     override fun updatePlaybackPosition(position: Long) {
         screenState.copyData { copy(playbackPosition = position) }
     }
+
+    override fun onPlaybackError() {
+        screenState.copyData { copy(hasPlaybackError = true, isPlaying = false) }
+    }
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
@@ -91,12 +91,16 @@ fun LessonContentLayout(
                     val playbackDuration = lesson.playbackDuration
                     val isPlaying = lesson.isPlaying
 
-                    AudioCardView(
-                        onPlayClick = onPlayClick,
-                        sliderPosition = sliderPosition.toFloat() / 1000f,
-                        playbackDuration = playbackDuration.toFloat() / 1000f,
-                        isPlaying = isPlaying,
-                    )
+                    if (lesson.hasPlaybackError) {
+                        PlaybackErrorView()
+                    } else {
+                        AudioCardView(
+                            onPlayClick = onPlayClick,
+                            sliderPosition = sliderPosition.toFloat() / 1000f,
+                            playbackDuration = playbackDuration.toFloat() / 1000f,
+                            isPlaying = isPlaying,
+                        )
+                    }
                 }
 
                 LessonContentTypes.TYPE_DIVIDER -> {
@@ -161,6 +165,24 @@ fun StyledImage(
             contentScale = ContentScale.FillWidth,
             contentDescription = contentDescription,
             modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+@Composable
+fun PlaybackErrorView() {
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        shape = RoundedCornerShape(28.dp),
+    ) {
+        Text(
+            text = "Playback unavailable",
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+            style = TextStyles.body(),
+            color = Colors.secondaryText(),
         )
     }
 }
@@ -230,4 +252,3 @@ fun AudioCardView(
         }
     }
 }
-

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
+import androidx.media3.common.PlaybackException
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import com.d4rk.englishwithlidia.plus.core.utils.extensions.await
@@ -53,6 +54,11 @@ abstract class ActivityPlayer : AppCompatActivity() {
                         val duration = player?.duration ?: 0L
                         playbackHandler.updatePlaybackDuration(duration)
                     }
+                }
+                override fun onPlayerError(error: PlaybackException) {
+                    playbackHandler.updateIsPlaying(false)
+                    playbackHandler.onPlaybackError()
+                    positionJob?.cancel()
                 }
             })
         }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/PlaybackEventHandler.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/PlaybackEventHandler.kt
@@ -4,4 +4,5 @@ interface PlaybackEventHandler {
     fun updateIsPlaying(isPlaying: Boolean)
     fun updatePlaybackDuration(duration: Long)
     fun updatePlaybackPosition(position: Long)
+    fun onPlaybackError()
 }


### PR DESCRIPTION
## Summary
- detect playback errors in player and notify view model
- show a placeholder message when playback fails
- track playback error state in lesson screen model

## Testing
- `./gradlew test` *(failed: /usr/bin/env: ‘sh’: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c81c3a61a0832dbfd46109ca35d9c8