### PR TITLE
test: add AudioPlaybackService callback tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,6 +161,7 @@ dependencies {
 
     // Unit Tests
     testImplementation(dependencyNotation = libs.bundles.unitTest)
+    testImplementation(dependencyNotation = libs.robolectric)
     testRuntimeOnly(dependencyNotation = libs.bundles.unitTestRuntime)
     testImplementation(dependencyNotation = "io.ktor:ktor-client-mock:3.2.3")
 

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/playback/AudioPlaybackServiceTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/playback/AudioPlaybackServiceTest.kt
@@ -1,0 +1,63 @@
+
+package com.d4rk.englishwithlidia.plus.playback
+
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.session.MediaSession
+import io.mockk.any
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.Robolectric
+import org.robolectric.junit5.RobolectricExtension
+
+@ExtendWith(RobolectricExtension::class)
+class AudioPlaybackServiceTest {
+
+    private fun createServiceWithMockPlayer(player: ExoPlayer): MediaSession.Callback {
+        val controller = Robolectric.buildService(AudioPlaybackService::class.java)
+        val service = controller.get()
+
+        val field = AudioPlaybackService::class.java.getDeclaredField("player\$delegate")
+        field.isAccessible = true
+        field.set(service, lazy { player })
+
+        controller.create()
+
+        val callbackClass = Class.forName("com.d4rk.englishwithlidia.plus.playback.AudioPlaybackService\$MediaSessionCallback")
+        val ctor = callbackClass.getDeclaredConstructor(AudioPlaybackService::class.java)
+        ctor.isAccessible = true
+        return ctor.newInstance(service) as MediaSession.Callback
+    }
+
+    @Test
+    fun `onAddMediaItems returns first item and updates player`() {
+        val mockPlayer = mockk<ExoPlayer>(relaxed = true)
+        val callback = createServiceWithMockPlayer(mockPlayer)
+
+        val item1 = MediaItem.Builder().setMediaId("1").build()
+        val item2 = MediaItem.Builder().setMediaId("2").build()
+        val items = mutableListOf(item1, item2)
+
+        val result = callback.onAddMediaItems(mockk<MediaSession>(), mockk<MediaSession.ControllerInfo>(), items).get()
+
+        assertEquals(listOf(item1), result)
+        verify(exactly = 1) { mockPlayer.clearMediaItems() }
+        verify(exactly = 1) { mockPlayer.setMediaItem(item1) }
+    }
+
+    @Test
+    fun `onAddMediaItems with empty list leaves player untouched`() {
+        val mockPlayer = mockk<ExoPlayer>(relaxed = true)
+        val callback = createServiceWithMockPlayer(mockPlayer)
+
+        val result = callback.onAddMediaItems(mockk<MediaSession>(), mockk<MediaSession.ControllerInfo>(), mutableListOf()).get()
+
+        assertTrue(result.isEmpty())
+        verify(exactly = 0) { mockPlayer.clearMediaItems() }
+        verify(exactly = 0) { mockPlayer.setMediaItem(any()) }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ testTurbine = "1.2.1"
 truth = "1.7.0"
 testManifestTestJunit4Android = "1.9.1"
 slf4j = "2.0.17"
+robolectric = "4.13.2"
 
 [libraries]
 media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
@@ -30,6 +31,7 @@ test-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-te
 test-turbine = { module = "app.cash.turbine:turbine", version.ref = "testTurbine" }
 androidx-truth = { module = "androidx.test.ext:truth", version.ref = "truth" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 # Instrumentation Tests (androidTest folder)
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }


### PR DESCRIPTION
## Summary
- add Robolectric test to validate AudioPlaybackService MediaSession callback
- ensure ExoPlayer interactions for media item addition

## Testing
- `PATH=/bin:/usr/bin:$PATH ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81ee737cc832d88e6b8e6acf0a7dd