### PR TITLE
Add Robolectric tests for EnglishWithLidia lifecycle behavior

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,6 +163,7 @@ dependencies {
     testImplementation(dependencyNotation = libs.bundles.unitTest)
     testRuntimeOnly(dependencyNotation = libs.bundles.unitTestRuntime)
     testImplementation(dependencyNotation = "io.ktor:ktor-client-mock:3.2.3")
+    testImplementation(dependencyNotation = libs.robolectric)
 
     // Instrumentation Tests
     androidTestImplementation(dependencyNotation = libs.bundles.instrumentationTest)

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/EnglishWithLidiaTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/EnglishWithLidiaTest.kt
@@ -1,0 +1,94 @@
+package com.d4rk.englishwithlidia.plus
+
+import android.app.Activity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
+import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+import org.robolectric.junit5.RobolectricExtension
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(RobolectricExtension::class)
+@Config(manifest = Config.NONE)
+class EnglishWithLidiaTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val adsCoreManager: AdsCoreManager = mockk(relaxed = true)
+    private val billingRepository: BillingRepository = mockk(relaxed = true)
+    private lateinit var app: EnglishWithLidia
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        startKoin {
+            modules(
+                module {
+                    single { adsCoreManager }
+                    single { billingRepository }
+                }
+            )
+        }
+        app = EnglishWithLidia()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        stopKoin()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `currentActivity is set and cleared`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        app.onActivityStarted(activity)
+        val field = EnglishWithLidia::class.java.getDeclaredField("currentActivity").apply { isAccessible = true }
+        org.junit.jupiter.api.Assertions.assertSame(activity, field.get(app))
+        app.onActivityStopped(activity)
+        org.junit.jupiter.api.Assertions.assertNull(field.get(app))
+    }
+
+    @Test
+    fun `onStart shows ad when activity present`() {
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val owner = testLifecycleOwner()
+        app.onActivityStarted(activity)
+        app.onStart(owner)
+        verify { adsCoreManager.showAdIfAvailable(activity, any()) }
+    }
+
+    @Test
+    fun `onResume processes past purchases`() = runTest {
+        val owner = testLifecycleOwner()
+        app.onResume(owner)
+        advanceUntilIdle()
+        coVerify { billingRepository.processPastPurchases() }
+    }
+
+    private fun testLifecycleOwner(): LifecycleOwner = object : LifecycleOwner {
+        private val registry = LifecycleRegistry(this).apply {
+            currentState = Lifecycle.State.STARTED
+        }
+        override fun getLifecycle(): Lifecycle = registry
+    }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ testTurbine = "1.2.1"
 truth = "1.7.0"
 testManifestTestJunit4Android = "1.9.1"
 slf4j = "2.0.17"
+robolectric = "4.13.2"
 
 [libraries]
 media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
@@ -30,6 +31,7 @@ test-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-te
 test-turbine = { module = "app.cash.turbine:turbine", version.ref = "testTurbine" }
 androidx-truth = { module = "androidx.test.ext:truth", version.ref = "truth" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 # Instrumentation Tests (androidTest folder)
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }


### PR DESCRIPTION
## Summary
- add Robolectric dependency for unit tests
- cover EnglishWithLidia lifecycle interactions with Robolectric and Koin mocks

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81ee40e5c832d8660004e861e20e6