### PR TITLE
test: add ListenableFuture await tests

### DIFF
--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/core/utils/extensions/ListenableFutureExtensionsTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/core/utils/extensions/ListenableFutureExtensionsTest.kt
@@ -1,0 +1,33 @@
+package com.d4rk.englishwithlidia.plus.core.utils.extensions
+
+import com.google.common.util.concurrent.SettableFuture
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ListenableFutureExtensionsTest {
+
+    @Test
+    fun `await returns value when future completes`() = runTest {
+        val future = SettableFuture.create<Int>()
+        future.set(42)
+
+        val result = future.await()
+
+        assertEquals(42, result)
+    }
+
+    @Test
+    fun `await cancels future when coroutine is cancelled`() = runTest {
+        val future = SettableFuture.create<Int>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) { future.await() }
+
+        job.cancelAndJoin()
+
+        assertTrue(future.isCancelled)
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for ListenableFuture.await extension

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c81ee604f8832da5e45301be46a943