### PR TITLE
Handle navigation drawer error message fallback

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/main/domain/model/UiMainScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/main/domain/model/UiMainScreen.kt
@@ -1,10 +1,11 @@
 package com.d4rk.englishwithlidia.plus.app.main.domain.model
 
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 
 data class UiMainScreen(
     val showSnackbar: Boolean = false,
-    val snackbarMessage: String = "",
+    val snackbarMessage: UiTextHelper? = null,
     val showDialog: Boolean = false,
     val navigationDrawerItems: List<NavigationDrawerItem> = listOf()
 )

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/main/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/main/ui/MainViewModel.kt
@@ -5,6 +5,8 @@ import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.NavigationRep
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.successData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.d4rk.englishwithlidia.plus.R
 import com.d4rk.englishwithlidia.plus.app.main.domain.action.MainAction
 import com.d4rk.englishwithlidia.plus.app.main.domain.action.MainEvent
 import com.d4rk.englishwithlidia.plus.app.main.domain.model.UiMainScreen
@@ -32,7 +34,12 @@ class MainViewModel(
                     screenState.successData {
                         copy(
                             showSnackbar = true,
-                            snackbarMessage = error.message ?: "Failed to load navigation"
+                            snackbarMessage = error.message
+                                ?.takeIf(String::isNotBlank)
+                                ?.let(UiTextHelper::DynamicString)
+                                ?: UiTextHelper.StringResource(
+                                    R.string.navigation_drawer_load_error
+                                )
                         )
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,8 @@
 <resources>
     <string name="app_short_description">Learn English and relax in the same time! 📚</string>
 
+    <string name="navigation_drawer_load_error">Failed to load navigation</string>
+
     <string name="find_us">Find us on</string>
     <string name="website">Website</string>
 

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/main/ui/MainViewModelTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/main/ui/MainViewModelTest.kt
@@ -2,6 +2,8 @@ package com.d4rk.englishwithlidia.plus.app.main.ui
 
 import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.NavigationRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.d4rk.englishwithlidia.plus.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -57,7 +59,23 @@ class MainViewModelTest {
 
         val state = viewModel.uiState.value.data!!
         assertTrue(state.showSnackbar)
-        assertEquals(errorMessage, state.snackbarMessage)
+        assertEquals(UiTextHelper.DynamicString(errorMessage), state.snackbarMessage)
+    }
+
+    @Test
+    fun `navigation drawer load error without message uses fallback string resource`() = runTest {
+        val failingFlow: Flow<List<NavigationDrawerItem>> = flow { throw RuntimeException() }
+        val repository = FakeNavigationRepository(failingFlow)
+        val viewModel = MainViewModel(repository)
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value.data!!
+        assertTrue(state.showSnackbar)
+        assertEquals(
+            UiTextHelper.StringResource(R.string.navigation_drawer_load_error),
+            state.snackbarMessage
+        )
     }
 
     private class FakeNavigationRepository(


### PR DESCRIPTION
## Summary
- replace the main screen snackbar message with `UiTextHelper` so it can carry string resources
- fall back to a dedicated navigation drawer load error string when the repository error message is blank
- extend `MainViewModelTest` to cover both custom error messages and the fallback resource

## Testing
- `./gradlew test` *(fails: Android SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c932e29e44832da2e3f731a6ee1793