### PR TITLE
Add tests for permissions special actions

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/settings/settings/utils/providers/PermissionsSettingsRepository.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/settings/settings/utils/providers/PermissionsSettingsRepository.kt
@@ -1,6 +1,8 @@
 package com.d4rk.englishwithlidia.plus.app.settings.settings.utils.providers
 
 import android.content.Context
+import android.content.Intent
+import android.provider.Settings
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.permissions.domain.repository.PermissionsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsCategory
@@ -70,6 +72,7 @@ class PermissionsSettingsRepository(
                                 SettingsPreference(
                                     title = context.getString(R.string.access_notification_policy),
                                     summary = context.getString(R.string.summary_preference_permissions_access_notification_policy),
+                                    action = { openSpecialPermissionSettings(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS) },
                                 ),
                             ),
                         ),
@@ -77,4 +80,12 @@ class PermissionsSettingsRepository(
                 ),
             )
         }.flowOn(dispatchers.io)
+
+    private fun openSpecialPermissionSettings(action: String) {
+        val intent = Intent(action).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        runCatching { context.startActivity(intent) }
+    }
 }

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/settings/settings/utils/providers/PermissionsSettingsRepositoryTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/settings/settings/utils/providers/PermissionsSettingsRepositoryTest.kt
@@ -1,0 +1,83 @@
+package com.d4rk.englishwithlidia.plus.app.settings.settings.utils.providers
+
+import android.content.Context
+import android.content.Intent
+import android.provider.Settings
+import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PermissionsSettingsRepositoryTest {
+
+    @Test
+    fun `getPermissionsConfig includes expected special permissions`() = runTest {
+        val context = createContextMock()
+        val dispatchers = createDispatcherProvider(UnconfinedTestDispatcher(testScheduler))
+        val repository = PermissionsSettingsRepository(context, dispatchers)
+
+        val config = repository.getPermissionsConfig().first()
+
+        val specialCategory = config.categories.first { it.title == SPECIAL_TITLE }
+        assertEquals(1, specialCategory.preferences.size)
+        val specialPreference = specialCategory.preferences.first()
+        assertEquals(SPECIAL_PERMISSION_TITLE, specialPreference.title)
+        assertEquals(SPECIAL_PERMISSION_SUMMARY, specialPreference.summary)
+    }
+
+    @Test
+    fun `special permission action launches notification policy settings`() = runTest {
+        val context = createContextMock()
+        val intentSlot = slot<Intent>()
+        every { context.startActivity(capture(intentSlot)) } just runs
+        val dispatchers = createDispatcherProvider(UnconfinedTestDispatcher(testScheduler))
+        val repository = PermissionsSettingsRepository(context, dispatchers)
+
+        val specialPreference = repository.getPermissionsConfig().first()
+            .categories.first { it.title == SPECIAL_TITLE }
+            .preferences.first()
+
+        specialPreference.action()
+
+        verify(exactly = 1) { context.startActivity(any()) }
+        val capturedIntent = intentSlot.captured
+        assertEquals(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS, capturedIntent.action)
+        assertTrue(
+            capturedIntent.flags and Intent.FLAG_ACTIVITY_NEW_TASK == Intent.FLAG_ACTIVITY_NEW_TASK,
+        )
+    }
+
+    private fun createContextMock(): Context {
+        val context: Context = mockk(relaxed = true)
+        every { context.getString(R.string.permissions) } returns "Permissions"
+        every { context.getString(R.string.special) } returns SPECIAL_TITLE
+        every { context.getString(R.string.access_notification_policy) } returns SPECIAL_PERMISSION_TITLE
+        every {
+            context.getString(R.string.summary_preference_permissions_access_notification_policy)
+        } returns SPECIAL_PERMISSION_SUMMARY
+        return context
+    }
+
+    private fun createDispatcherProvider(ioDispatcher: kotlinx.coroutines.CoroutineDispatcher): DispatcherProvider =
+        mockk(relaxed = true) {
+            every { io } returns ioDispatcher
+        }
+
+    private companion object {
+        const val SPECIAL_TITLE = "Special"
+        const val SPECIAL_PERMISSION_TITLE = "Notification policy access"
+        const val SPECIAL_PERMISSION_SUMMARY = "Allows access to notification policy"
+    }
+}


### PR DESCRIPTION
## Summary
- launch the notification policy settings when the special permission item is tapped
- cover the permissions repository with unit tests for the special entry and its intent

## Testing
- `./gradlew test` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c932de6c30832dbde59d374f46a5e2