### PR TITLE
Add tests for ActivityPlayer playback events

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,6 +163,7 @@ dependencies {
     testImplementation(dependencyNotation = libs.bundles.unitTest)
     testRuntimeOnly(dependencyNotation = libs.bundles.unitTestRuntime)
     testImplementation(dependencyNotation = "io.ktor:ktor-client-mock:3.2.3")
+    testImplementation(dependencyNotation = libs.robolectric)
 
     // Instrumentation Tests
     androidTestImplementation(dependencyNotation = libs.bundles.instrumentationTest)

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayerTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayerTest.kt
@@ -1,0 +1,131 @@
+package com.d4rk.englishwithlidia.plus.app.player
+
+import android.os.Looper
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.session.MediaController
+import com.google.common.truth.Truth.assertThat
+import com.google.common.util.concurrent.Futures
+import io.mockk.anyConstructed
+import io.mockk.every
+import io.mockk.firstArg
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.junit5.RobolectricExtension
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(RobolectricExtension::class)
+class ActivityPlayerTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var playbackHandler: PlaybackEventHandler
+    private lateinit var fakePlayer: MediaController
+    private lateinit var playerListener: Player.Listener
+    private lateinit var activityController: ActivityController<TestActivityPlayer>
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+
+        playbackHandler = mockk(relaxed = true)
+        fakePlayer = mockk(relaxed = true)
+
+        mockkConstructor(MediaController.Builder::class)
+        every { anyConstructed<MediaController.Builder>().buildAsync() } returns
+            Futures.immediateFuture(fakePlayer)
+        every { fakePlayer.addListener(any()) } answers {
+            playerListener = firstArg()
+            Unit
+        }
+
+        activityController = Robolectric.buildActivity(TestActivityPlayer::class.java)
+        val activity = activityController.get()
+        activity.setPlaybackHandler(playbackHandler)
+        activityController.setup()
+
+        Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+        assertThat(::playerListener.isInitialized).isTrue()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        if (::activityController.isInitialized) {
+            activityController.pause().destroy()
+        }
+        unmockkConstructor(MediaController.Builder::class)
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun onIsPlayingChanged_trueUpdatesStateAndPosition() {
+        val expectedPosition = 1_500L
+        every { fakePlayer.currentPosition } returns expectedPosition
+        every { fakePlayer.isPlaying } returns false
+
+        playerListener.onIsPlayingChanged(true)
+
+        verify(exactly = 1) { playbackHandler.updateIsPlaying(true) }
+        verify(timeout = 1_000, exactly = 1) {
+            playbackHandler.updatePlaybackPosition(expectedPosition)
+        }
+    }
+
+    @Test
+    fun onIsPlayingChanged_falseUpdatesState() {
+        playerListener.onIsPlayingChanged(false)
+
+        verify(exactly = 1) { playbackHandler.updateIsPlaying(false) }
+    }
+
+    @Test
+    fun onPlaybackStateReady_updatesDuration() {
+        val expectedDuration = 12_345L
+        every { fakePlayer.duration } returns expectedDuration
+
+        playerListener.onPlaybackStateChanged(Player.STATE_READY)
+
+        verify(exactly = 1) { playbackHandler.updatePlaybackDuration(expectedDuration) }
+    }
+
+    @Test
+    fun onPlayerError_notifiesHandler() {
+        val playbackException = PlaybackException(
+            "test error",
+            null,
+            PlaybackException.ERROR_CODE_UNKNOWN
+        )
+
+        playerListener.onPlayerError(playbackException)
+
+        verify(exactly = 1) { playbackHandler.updateIsPlaying(false) }
+        verify(exactly = 1) { playbackHandler.onPlaybackError() }
+    }
+
+    private class TestActivityPlayer : ActivityPlayer() {
+
+        private var handler: PlaybackEventHandler? = null
+
+        override val playbackHandler: PlaybackEventHandler
+            get() = handler ?: error("Playback handler not set")
+
+        fun setPlaybackHandler(playbackHandler: PlaybackEventHandler) {
+            handler = playbackHandler
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ testTurbine = "1.2.1"
 truth = "1.7.0"
 testManifestTestJunit4Android = "1.9.1"
 slf4j = "2.0.17"
+robolectric = "4.16"
 
 [libraries]
 media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
@@ -30,6 +31,7 @@ test-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-te
 test-turbine = { module = "app.cash.turbine:turbine", version.ref = "testTurbine" }
 androidx-truth = { module = "androidx.test.ext:truth", version.ref = "truth" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 # Instrumentation Tests (androidTest folder)
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }


### PR DESCRIPTION
## Summary
- add Robolectric to the test dependencies for JVM unit tests
- add ActivityPlayer Robolectric test that uses a mocked PlaybackEventHandler to verify listener callbacks

## Testing
- `./gradlew test` *(fails: Android SDK not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c932c3cf58832da5b66ca03731f05c