### PR TITLE
Remove lifecycle observer when application terminates

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/EnglishWithLidia.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/EnglishWithLidia.kt
@@ -64,4 +64,9 @@ class EnglishWithLidia : BaseCoreManager(), DefaultLifecycleObserver {
             currentActivity = null
         }
     }
+
+    override fun onTerminate() {
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(this)
+        super<BaseCoreManager>.onTerminate()
+    }
 }

--- a/app/src/test/kotlin/com/d4rk/englishwithlidia/plus/EnglishWithLidiaTest.kt
+++ b/app/src/test/kotlin/com/d4rk/englishwithlidia/plus/EnglishWithLidiaTest.kt
@@ -1,0 +1,40 @@
+package com.d4rk.englishwithlidia.plus
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+class EnglishWithLidiaTest {
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `onTerminate removes ProcessLifecycleOwner observer`() {
+        mockkStatic(ProcessLifecycleOwner::class)
+
+        val processLifecycle = mockk<Lifecycle>(relaxUnitFun = true)
+        val lifecycleOwner = mockk<LifecycleOwner> {
+            every { lifecycle } returns processLifecycle
+        }
+
+        every { ProcessLifecycleOwner.get() } returns lifecycleOwner
+
+        val application = EnglishWithLidia()
+
+        runCatching { application.onTerminate() }
+
+        verify(exactly = 1) {
+            processLifecycle.removeObserver(application)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove the ProcessLifecycleOwner observer when the application terminates
- cover the lifecycle cleanup with a unit test that verifies the observer is removed

## Testing
- ./gradlew test *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c932b8589c832da4508bc04d45189c