### PR TITLE
Add unit tests for audio cache eviction worker

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/data/audio/AudioCacheEvictionWorker.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/data/audio/AudioCacheEvictionWorker.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.d4rk.android.libs.apptoolkit.core.di.StandardDispatchers
+import kotlinx.coroutines.CancellationException
 
 class AudioCacheEvictionWorker(
     appContext: Context,
@@ -12,8 +13,12 @@ class AudioCacheEvictionWorker(
 
     private val manager = AudioCacheManager(appContext, StandardDispatchers())
 
-    override suspend fun doWork(): Result {
+    override suspend fun doWork(): Result = try {
         manager.evictStaleEntries()
-        return Result.success()
+        Result.success()
+    } catch (cancellationException: CancellationException) {
+        throw cancellationException
+    } catch (exception: Exception) {
+        Result.failure()
     }
 }

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/core/data/audio/AudioCacheEvictionWorkerTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/core/data/audio/AudioCacheEvictionWorkerTest.kt
@@ -1,0 +1,58 @@
+package com.d4rk.englishwithlidia.plus.core.data.audio
+
+import android.content.Context
+import androidx.work.ListenableWorker.Result
+import androidx.work.WorkerParameters
+import io.mockk.anyConstructed
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AudioCacheEvictionWorkerTest {
+
+    private val context: Context = mockk(relaxed = true).apply {
+        every { applicationContext } returns this@apply
+    }
+    private val workerParameters: WorkerParameters = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        mockkConstructor(AudioCacheManager::class)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkConstructor(AudioCacheManager::class)
+    }
+
+    @Test
+    fun `doWork returns success when eviction succeeds`() = runTest {
+        coEvery { anyConstructed<AudioCacheManager>().evictStaleEntries() } returns Unit
+
+        val worker = AudioCacheEvictionWorker(context, workerParameters)
+
+        val result = worker.doWork()
+
+        assertEquals(Result.success(), result)
+    }
+
+    @Test
+    fun `doWork returns failure when eviction throws`() = runTest {
+        coEvery { anyConstructed<AudioCacheManager>().evictStaleEntries() } throws IllegalStateException()
+
+        val worker = AudioCacheEvictionWorker(context, workerParameters)
+
+        val result = worker.doWork()
+
+        assertEquals(Result.failure(), result)
+    }
+}


### PR DESCRIPTION
## Summary
- handle eviction failures in `AudioCacheEvictionWorker` by returning `Result.failure()`
- add `AudioCacheEvictionWorkerTest` to verify success and failure flows when `AudioCacheManager` is mocked

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c932ad4758832dbb7f6256cbcb6a54