### PR TITLE
Bundle Media3 dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -162,10 +162,8 @@ dependencies {
     }
 
 
-    // AndroidX Media3 ExoPlayer
-    implementation(dependencyNotation = libs.media3.exoplayer)
-    implementation(dependencyNotation = libs.media3.ui)
-    implementation(dependencyNotation = libs.media3.session)
+    // AndroidX Media3
+    implementation(dependencyNotation = libs.bundles.media3)
 
     // Unit Tests
     testImplementation(dependencyNotation = libs.bundles.unitTest)

--- a/docs/core/media3-deep-dive.md
+++ b/docs/core/media3-deep-dive.md
@@ -39,12 +39,10 @@ Migrating from standalone ExoPlayer is recommended, as Media3 is now the officia
 
 ## In This Repository
 
-This project already uses Media3 ExoPlayer, session, and UI libraries in `app/build.gradle.kts`:
+This project already uses the Media3 dependency bundle in `app/build.gradle.kts`:
 
 ```kotlin
-implementation(dependencyNotation = libs.media3.exoplayer)
-implementation(dependencyNotation = libs.media3.ui)
-implementation(dependencyNotation = libs.media3.session)
+implementation(dependencyNotation = libs.bundles.media3)
 ```
 
 The `LessonViewModel` class demonstrates basic playback using an `ExoPlayer` instance.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,11 @@ about-libraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "ab
 mannodermaus = { id = "de.mannodermaus.android-junit5", version.ref = "mannodermaus" }
 
 [bundles]
+media3 = [
+    "media3-exoplayer",
+    "media3-ui",
+    "media3-session",
+]
 # For local tests on the JVM (test sourceSet)
 unitTest = [
     "jupiter-api",


### PR DESCRIPTION
## Summary
- add a Media3 dependency bundle to the shared version catalog
- update the app module to consume the Media3 bundle
- refresh the Media3 documentation snippet to reflect the bundled dependency usage

## Testing
- ./gradlew test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd2030f2c0832d85556b1fabc68b8f