### PR TITLE
Replace lesson audio progress with interactive wavy slider

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,6 +161,8 @@ dependencies {
         isTransitive = true
     }
 
+    implementation(dependencyNotation = "ir.mahozad.multiplatform:wavy-slider:2.1.0")
+
 
     // AndroidX Media3
     implementation(dependencyNotation = libs.bundles.media3)

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonActivity.kt
@@ -32,6 +32,9 @@ class LessonActivity : ActivityPlayer() {
                     mediumRectangleConfig = mediumRectangleConfig,
                     onBack = { finish() },
                     onPlayClick = { playPause() },
+                    onSeek = { positionInSeconds ->
+                        seekTo((positionInSeconds * 1000).toLong())
+                    },
                     onPreparePlayer = { content, lessonTitle ->
                         preparePlayer(
                             audioUrl = content.contentAudioUrl,

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonScreen.kt
@@ -28,6 +28,7 @@ fun LessonScreen(
     mediumRectangleConfig: AdsConfig,
     onBack: () -> Unit,
     onPlayClick: () -> Unit,
+    onSeek: (Float) -> Unit,
     onPreparePlayer: (UiLessonContent, String) -> Unit,
 ) {
     val listState = rememberLazyListState()
@@ -66,6 +67,7 @@ fun LessonScreen(
                     bannerConfig = bannerConfig,
                     mediumRectangleConfig = mediumRectangleConfig,
                     onPlayClick = onPlayClick,
+                    onSeek = onSeek,
                 )
             },
         )

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
@@ -107,6 +107,11 @@ abstract class ActivityPlayer : AppCompatActivity() {
         }
     }
 
+    fun seekTo(positionMillis: Long) {
+        player?.seekTo(positionMillis)
+        playbackHandler.updatePlaybackPosition(positionMillis)
+    }
+
     private fun startPositionUpdates() {
         positionJob?.cancel()
         positionJob = lifecycleScope.launch(Dispatchers.Default) {


### PR DESCRIPTION
## Summary
- add the wavy-slider dependency to the app module
- replace the static LinearWavyProgressIndicator with an interactive WavySlider in the lesson audio card
- thread seek callbacks from the activity down to the slider and expose a seekTo helper on ActivityPlayer

## Testing
- ./gradlew test *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfca387ca4832d89da23677430005f