### PR TITLE
Replace WavySlider with Material3 slider

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,9 +161,6 @@ dependencies {
         isTransitive = true
     }
 
-    implementation(dependencyNotation = "ir.mahozad.multiplatform:wavy-slider:2.1.0")
-
-
     // AndroidX Media3
     implementation(dependencyNotation = libs.bundles.media3)
 

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/components/LessonContentLayout.kt
@@ -19,12 +19,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Card
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -50,7 +50,6 @@ import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLess
 import com.d4rk.englishwithlidia.plus.app.settings.display.theme.style.Colors
 import com.d4rk.englishwithlidia.plus.app.settings.display.theme.style.TextStyles
 import com.d4rk.englishwithlidia.plus.core.utils.constants.ui.lessons.LessonContentTypes
-import ir.mahozad.multiplatform.wavyslider.material3.WavySlider as WavySlider3
 
 @Composable
 fun LessonContentLayout(
@@ -193,7 +192,7 @@ fun PlaybackErrorView() {
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AudioCardView(
     onPlayClick: () -> Unit,
@@ -247,24 +246,23 @@ fun AudioCardView(
 
                 Spacer(modifier = Modifier.width(16.dp))
 
-                WavySlider3(
+                Slider(
                     value = sliderValue,
                     onValueChange = { value ->
                         isDragging = true
                         sliderValue = value
                     },
+                    modifier = Modifier
+                        .weight(4f)
+                        .fillMaxWidth(),
+                    enabled = playbackDuration > 0f,
+                    valueRange = 0f..sliderMax,
                     onValueChangeFinished = {
                         val targetValue = sliderValue.coerceIn(0f, sliderMax)
                         sliderValue = targetValue
                         onSeek(targetValue)
                         isDragging = false
                     },
-                    valueRange = 0f..sliderMax,
-                    enabled = playbackDuration > 0f,
-                    waveHeight = if (isPlaying) 12.dp else 0.dp,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(4f),
                 )
             }
         }


### PR DESCRIPTION
## Summary
- swap the lesson audio seek bar to the standard Material3 `Slider`
- drop the WavySlider dependency and the forced Material3 resolution override that it required

## Testing
- `./gradlew test` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe4ba727c832d9ca036355fd4ca09