### PR TITLE
Show buffering indicator for lesson audio playback

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/model/ui/UiLessonScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/model/ui/UiLessonScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Immutable
 @Immutable
 data class UiLessonScreen(
     val isPlaying: Boolean = false,
+    val isBuffering: Boolean = false,
     val playbackPosition: Long = 0L,
     val playbackDuration: Long = 0L,
     val hasPlaybackError: Boolean = false,

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/ui/LessonViewModel.kt
@@ -56,6 +56,10 @@ class LessonViewModel(
         screenState.copyData { copy(isPlaying = isPlaying) }
     }
 
+    override fun updateIsBuffering(isBuffering: Boolean) {
+        screenState.copyData { copy(isBuffering = isBuffering) }
+    }
+
     override fun updatePlaybackDuration(duration: Long) {
         screenState.copyData { copy(playbackDuration = duration) }
     }
@@ -65,6 +69,8 @@ class LessonViewModel(
     }
 
     override fun onPlaybackError() {
-        screenState.copyData { copy(hasPlaybackError = true, isPlaying = false) }
+        screenState.copyData {
+            copy(hasPlaybackError = true, isPlaying = false, isBuffering = false)
+        }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/ActivityPlayer.kt
@@ -50,13 +50,24 @@ abstract class ActivityPlayer : AppCompatActivity() {
                 }
 
                 override fun onPlaybackStateChanged(playbackState: Int) {
-                    if (playbackState == Player.STATE_READY) {
-                        val duration = player?.duration ?: 0L
-                        playbackHandler.updatePlaybackDuration(duration)
+                    when (playbackState) {
+                        Player.STATE_BUFFERING -> {
+                            val shouldShowBuffering = player?.playWhenReady == true
+                            playbackHandler.updateIsBuffering(shouldShowBuffering)
+                        }
+                        Player.STATE_READY -> {
+                            playbackHandler.updateIsBuffering(false)
+                            val duration = player?.duration ?: 0L
+                            playbackHandler.updatePlaybackDuration(duration)
+                        }
+                        Player.STATE_IDLE, Player.STATE_ENDED -> {
+                            playbackHandler.updateIsBuffering(false)
+                        }
                     }
                 }
                 override fun onPlayerError(error: PlaybackException) {
                     playbackHandler.updateIsPlaying(false)
+                    playbackHandler.updateIsBuffering(false)
                     playbackHandler.onPlaybackError()
                     positionJob?.cancel()
                 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/PlaybackEventHandler.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/player/PlaybackEventHandler.kt
@@ -2,6 +2,7 @@ package com.d4rk.englishwithlidia.plus.app.player
 
 interface PlaybackEventHandler {
     fun updateIsPlaying(isPlaying: Boolean)
+    fun updateIsBuffering(isBuffering: Boolean)
     fun updatePlaybackDuration(duration: Long)
     fun updatePlaybackPosition(position: Long)
     fun onPlaybackError()


### PR DESCRIPTION
## Summary
- track lesson buffering state in the UI model and view model so the player can react to it
- show a circular progress indicator in the audio card while buffering and surface playback errors with stacked cards and animated corners
- report buffering events from the activity player through the playback handler interface

## Testing
- ./gradlew test *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cffd5478c8832da09eb6276ca13c5f