### PR TITLE
Refine home lessons state handling

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModel.kt
@@ -10,7 +10,16 @@ import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.mapper.HomeUiMappe
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.usecases.GetHomeLessonsUseCase
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -18,40 +27,70 @@ class HomeViewModel(
     private val getHomeLessonsUseCase: GetHomeLessonsUseCase,
     private val uiMapper: HomeUiMapper,
 ) : ScreenViewModel<UiHomeScreen, HomeEvent, HomeAction>(
-    initialState = UiStateScreen(screenState = ScreenState.IsLoading(), data = UiHomeScreen())
+    initialState = INITIAL_STATE
 ) {
 
+    private val refreshActions = MutableSharedFlow<HomeEvent>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    private val lessonsState = refreshActions
+        .onStart { emit(HomeEvent.FetchLessons) }
+        .flatMapLatest { event ->
+            when (event) {
+                HomeEvent.FetchLessons -> observeHomeLessons()
+            }
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = INITIAL_STATE,
+        )
+
     init {
-        onEvent(HomeEvent.FetchLessons)
+        viewModelScope.launch {
+            lessonsState.collect { newState ->
+                screenState.update { newState }
+            }
+        }
     }
 
     override fun onEvent(event: HomeEvent) {
-        when (event) {
-            HomeEvent.FetchLessons -> getHomeLessons()
+        if (!refreshActions.tryEmit(event)) {
+            viewModelScope.launch { refreshActions.emit(event) }
         }
     }
 
-    private fun getHomeLessons() {
-        viewModelScope.launch {
-            getHomeLessonsUseCase()
-                .catch { throwable ->
-                    if (throwable is CancellationException) throw throwable
-                    screenState.update { current ->
-                        current.copy(screenState = ScreenState.NoData(), data = UiHomeScreen())
-                    }
+    private fun observeHomeLessons(): Flow<UiStateScreen<UiHomeScreen>> =
+        getHomeLessonsUseCase()
+            .map { homeScreen -> uiMapper.map(homeScreen) }
+            .map { uiScreen ->
+                if (uiScreen.lessons.isEmpty()) {
+                    UiStateScreen(
+                        screenState = ScreenState.NoData(),
+                        data = UiHomeScreen(),
+                    )
+                } else {
+                    UiStateScreen(
+                        screenState = ScreenState.Success(),
+                        data = uiScreen,
+                    )
                 }
-                .collect { homeScreen ->
-                    val uiScreen = uiMapper.map(homeScreen)
-                    if (uiScreen.lessons.isEmpty()) {
-                        screenState.update { current ->
-                            current.copy(screenState = ScreenState.NoData(), data = UiHomeScreen())
-                        }
-                    } else {
-                        screenState.update { current ->
-                            current.copy(screenState = ScreenState.Success(), data = uiScreen)
-                        }
-                    }
-                }
-        }
+            }
+            .onStart {
+                emit(screenState.value.copy(screenState = ScreenState.IsLoading()))
+            }
+            .catch { throwable ->
+                if (throwable is CancellationException) throw throwable
+                emit(UiStateScreen(screenState = ScreenState.NoData(), data = UiHomeScreen()))
+            }
+            .distinctUntilChanged()
+
+    private companion object {
+        private val INITIAL_STATE = UiStateScreen(
+            screenState = ScreenState.IsLoading(),
+            data = UiHomeScreen(),
+        )
     }
 }

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModelTest.kt
@@ -2,6 +2,7 @@ package com.d4rk.englishwithlidia.plus.app.lessons.list.ui
 
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.action.HomeEvent
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.mapper.HomeUiMapper
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeLesson
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
@@ -53,6 +54,20 @@ class HomeViewModelTest {
         advanceUntilIdle()
 
         verify(exactly = 1) { repository.getHomeLessons() }
+    }
+
+    @Test
+    fun `fetch event triggers lessons reload`() = runTest {
+        val repository = mockk<HomeRepository>()
+        every { repository.getHomeLessons() } returns flowOf(HomeScreen())
+
+        val viewModel = HomeViewModel(GetHomeLessonsUseCase(repository), HomeUiMapper())
+        advanceUntilIdle()
+
+        viewModel.onEvent(HomeEvent.FetchLessons)
+        advanceUntilIdle()
+
+        verify(exactly = 2) { repository.getHomeLessons() }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- refactor `HomeViewModel` to drive UI state from a shared flow backed by `stateIn` and lifecycle-aware loading/error handling
- ensure lesson reload events re-trigger fetching while preserving previous data during loading transitions
- extend unit coverage to verify manual refresh triggers a second repository fetch

## Testing
- `./gradlew test` *(fails: Android SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1608bae20832d8ec25403d2380fd7