### PR TITLE
Refine lessons list UI dependency flow

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeScreen.kt
@@ -5,16 +5,23 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.WifiTetheringError
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.action.HomeEvent
+import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeLesson
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
 import com.d4rk.englishwithlidia.plus.app.lessons.list.ui.components.LessonListLayout
+import com.d4rk.englishwithlidia.plus.app.main.ui.components.navigation.openLessonDetailActivity
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.qualifier.named
 
 @Composable
 fun HomeRoute(
@@ -22,10 +29,25 @@ fun HomeRoute(
     viewModel: HomeViewModel = koinViewModel(),
 ) {
     val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val bannerAdsConfig: AdsConfig = koinInject()
+    val mediumRectangleAdsConfig: AdsConfig =
+        koinInject(qualifier = named(name = "banner_medium_rectangle"))
+    val onLessonSelected: (UiHomeLesson) -> Unit = remember(context) {
+        { lesson ->
+            openLessonDetailActivity(
+                context = context,
+                lesson = lesson,
+            )
+        }
+    }
 
     HomeScreen(
         screenState = screenState,
         onRetry = { viewModel.onEvent(event = HomeEvent.FetchLessons) },
+        onLessonSelected = onLessonSelected,
+        bannerAdsConfig = bannerAdsConfig,
+        mediumRectangleAdsConfig = mediumRectangleAdsConfig,
         paddingValues = paddingValues,
     )
 }
@@ -35,6 +57,9 @@ fun HomeRoute(
 fun HomeScreen(
     screenState: UiStateScreen<UiHomeScreen>,
     onRetry: () -> Unit,
+    onLessonSelected: (UiHomeLesson) -> Unit,
+    bannerAdsConfig: AdsConfig,
+    mediumRectangleAdsConfig: AdsConfig,
     paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
@@ -51,6 +76,9 @@ fun HomeScreen(
         onSuccess = { uiHomeScreen ->
             LessonListLayout(
                 lessons = uiHomeScreen.lessons,
+                bannerAdsConfig = bannerAdsConfig,
+                mediumRectangleAdsConfig = mediumRectangleAdsConfig,
+                onLessonClick = onLessonSelected,
                 paddingValues = paddingValues,
                 modifier = modifier,
             )

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/components/LessonListLayout.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/components/LessonListLayout.kt
@@ -26,13 +26,10 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -43,25 +40,20 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.englishwithlidia.plus.R
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeLesson
-import com.d4rk.englishwithlidia.plus.app.main.ui.components.navigation.openLessonDetailActivity
 import com.d4rk.englishwithlidia.plus.core.utils.constants.ui.lessons.LessonConstants
-import org.koin.compose.koinInject
-import org.koin.core.qualifier.named
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun LessonListLayout(
     lessons: List<UiHomeLesson>,
+    bannerAdsConfig: AdsConfig,
+    mediumRectangleAdsConfig: AdsConfig,
+    onLessonClick: (UiHomeLesson) -> Unit,
     paddingValues: PaddingValues,
     modifier: Modifier = Modifier,
 ) {
-    val bannerConfig: AdsConfig = koinInject()
-    val mediumRectangleConfig: AdsConfig =
-        koinInject(qualifier = named(name = "banner_medium_rectangle"))
     val listState = rememberLazyListState()
-    val items by remember(lessons) {
-        derivedStateOf { buildAppListItems(lessons) }
-    }
+    val items = remember(lessons) { buildAppListItems(lessons) }
 
     LazyColumn(
         modifier = modifier
@@ -105,16 +97,17 @@ fun LessonListLayout(
                 )
                 LessonListItem.BannerAd ->
                     BannerAdView(
-                        adsConfig = bannerConfig,
+                        adsConfig = bannerAdsConfig,
                     )
 
                 LessonListItem.MediumRectangleAd ->
                     MediumRectangleAdView(
-                        adsConfig = mediumRectangleConfig,
+                        adsConfig = mediumRectangleAdsConfig,
                     )
 
                 is LessonListItem.Lesson -> LessonCardItem(
                     lesson = item.lesson,
+                    onLessonClick = onLessonClick,
                     modifier = Modifier
                         .animateVisibility(index = index)
                         .animateItem()
@@ -192,16 +185,13 @@ private fun MediumRectangleAdView(
 @Composable
 private fun LessonCardItem(
     lesson: UiHomeLesson,
+    onLessonClick: (UiHomeLesson) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-    val onLessonClick = remember(context, lesson) {
-        { openLessonDetailActivity(context = context, lesson = lesson) }
-    }
     LessonCard(
         title = lesson.lessonTitle,
         imageResource = lesson.lessonThumbnailImageUrl,
-        onClick = onLessonClick,
+        onClick = { onLessonClick(lesson) },
         modifier = modifier,
     )
 }


### PR DESCRIPTION
## Summary
- hoist lesson navigation and ad configuration dependencies from reusable composables into the HomeRoute/HomeScreen layer
- update LessonListLayout to accept ad configs and click callbacks via parameters for better state hoisting

## Testing
- `./gradlew test` *(fails: Android SDK is not configured in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d167634c40832d9d00d782280ce6d1