### PR TITLE
Refactor lesson details architecture to use domain models and Flow

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonMapper.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonMapper.kt
@@ -1,16 +1,17 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.details.data
 
-import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonContent
-import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.Lesson
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.LessonContent
 import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiLessonResponse
 
 class LessonMapper {
-    fun map(response: ApiLessonResponse): List<UiLessonScreen> {
+
+    fun map(response: ApiLessonResponse): List<Lesson> {
         return response.data.map { networkLesson ->
-            UiLessonScreen(
+            Lesson(
                 lessonTitle = networkLesson.lessonTitle,
                 lessonContent = networkLesson.lessonContent.map { networkContent ->
-                    UiLessonContent(
+                    LessonContent(
                         contentId = networkContent.contentId,
                         contentType = networkContent.contentType,
                         contentText = networkContent.contentText,

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/mapper/LessonUiMapper.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/mapper/LessonUiMapper.kt
@@ -1,0 +1,33 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.details.domain.mapper
+
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.Lesson
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.LessonContent
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonContent
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
+
+class LessonUiMapper {
+
+    fun map(lesson: Lesson): UiLessonScreen {
+        return UiLessonScreen(
+            lessonTitle = lesson.lessonTitle,
+            lessonContent = lesson.lessonContent.map(::mapContent),
+        )
+    }
+
+    private fun mapContent(content: LessonContent): UiLessonContent {
+        return UiLessonContent(
+            contentId = content.contentId,
+            contentType = content.contentType,
+            contentText = content.contentText,
+            contentImageUrl = content.contentImageUrl,
+            contentAudioUrl = content.contentAudioUrl,
+            contentThumbnailUrl = content.contentThumbnailUrl,
+            contentTitle = content.contentTitle,
+            contentArtist = content.contentArtist,
+            contentAlbumTitle = content.contentAlbumTitle,
+            contentGenre = content.contentGenre,
+            contentDescription = content.contentDescription,
+            contentReleaseYear = content.contentReleaseYear,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/model/Lesson.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/model/Lesson.kt
@@ -1,0 +1,31 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * Represents the business data for a lesson before it is adapted for the UI layer.
+ */
+@Immutable
+data class Lesson(
+    val lessonTitle: String = "",
+    val lessonContent: List<LessonContent> = emptyList(),
+)
+
+/**
+ * Represents the raw lesson content returned by the backend service.
+ */
+@Immutable
+data class LessonContent(
+    val contentId: String = "",
+    val contentType: String = "",
+    val contentText: String = "",
+    val contentImageUrl: String = "",
+    val contentAudioUrl: String = "",
+    val contentThumbnailUrl: String = "",
+    val contentTitle: String = "",
+    val contentArtist: String = "",
+    val contentAlbumTitle: String = "",
+    val contentGenre: String = "",
+    val contentDescription: String = "",
+    val contentReleaseYear: Int? = null,
+)

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/repository/LessonRepository.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/repository/LessonRepository.kt
@@ -1,7 +1,8 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.details.domain.repository
 
-import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.Lesson
+import kotlinx.coroutines.flow.Flow
 
 interface LessonRepository {
-    suspend fun getLesson(lessonId: String): UiLessonScreen
+    fun getLesson(lessonId: String): Flow<Lesson?>
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/usecases/GetLessonUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/usecases/GetLessonUseCase.kt
@@ -1,10 +1,11 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.details.domain.usecases
 
-import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.Lesson
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.repository.LessonRepository
+import kotlinx.coroutines.flow.Flow
 
 class GetLessonUseCase(private val repository: LessonRepository) {
-    suspend operator fun invoke(lessonId: String): UiLessonScreen {
+    operator fun invoke(lessonId: String): Flow<Lesson?> {
         return repository.getLesson(lessonId)
     }
 }

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AppModule.kt
@@ -8,6 +8,7 @@ import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
 import com.d4rk.englishwithlidia.plus.BuildConfig
 import com.d4rk.englishwithlidia.plus.app.lessons.details.data.LessonMapper
 import com.d4rk.englishwithlidia.plus.app.lessons.details.data.LessonRepositoryImpl
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.mapper.LessonUiMapper
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.repository.LessonRepository
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.usecases.GetLessonUseCase
 import com.d4rk.englishwithlidia.plus.app.lessons.details.ui.LessonViewModel
@@ -21,6 +22,7 @@ import com.d4rk.englishwithlidia.plus.app.main.ui.MainViewModel
 import com.d4rk.englishwithlidia.plus.app.onboarding.utils.interfaces.providers.AppOnboardingProvider
 import com.d4rk.englishwithlidia.plus.core.data.audio.AudioCacheManager
 import com.d4rk.englishwithlidia.plus.core.data.datastore.DataStore
+import kotlinx.serialization.json.Json
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
@@ -60,14 +62,22 @@ val appModule: Module = module {
 
     single { LessonMapper() }
     single { AudioCacheManager(context = get(), dispatchers = get()) }
+    single<Json>(qualifier = named("lessons_json_parser")) {
+        Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+        }
+    }
     single<LessonRepository> {
         LessonRepositoryImpl(
             client = get(),
             dispatchers = get(),
             mapper = get(),
-            audioCache = get()
+            audioCache = get(),
+            jsonParser = get(named("lessons_json_parser")),
         )
     }
     factory { GetLessonUseCase(repository = get()) }
-    viewModel { LessonViewModel(getLessonUseCase = get()) }
+    single { LessonUiMapper() }
+    viewModel { LessonViewModel(getLessonUseCase = get(), uiMapper = get()) }
 }

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonMapperTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/details/data/LessonMapperTest.kt
@@ -1,7 +1,7 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.details.data
 
-import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonContent
-import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.Lesson
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.LessonContent
 import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiLesson
 import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiLessonContent
 import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiLessonResponse
@@ -14,12 +14,12 @@ class LessonMapperTest {
     private val mapper = LessonMapper()
 
     @Test
-    fun `map maps api response with data to ui lessons`() {
+    fun `map maps api response with data to domain lessons`() {
         val apiResponse = createLessonApiResponse()
 
         val result = mapper.map(apiResponse)
 
-        assertEquals(listOf(expectedUiLesson()), result)
+        assertEquals(listOf(expectedLesson()), result)
     }
 
     @Test
@@ -42,9 +42,9 @@ class LessonMapperTest {
 
     private fun createEmptyLessonApiResponse() = ApiLessonResponse(data = emptyList())
 
-    private fun expectedUiLesson() = UiLessonScreen(
+    private fun expectedLesson() = Lesson(
         lessonTitle = LESSON_TITLE,
-        lessonContent = sampleContents.map { it.toUi() },
+        lessonContent = sampleContents.map { it.toDomain() },
     )
 
     private data class LessonContentSample(
@@ -76,7 +76,7 @@ class LessonMapperTest {
             contentReleaseYear = releaseYear,
         )
 
-        fun toUi() = UiLessonContent(
+        fun toDomain() = LessonContent(
             contentId = id,
             contentType = type,
             contentText = text,

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/mapper/LessonUiMapperTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/mapper/LessonUiMapperTest.kt
@@ -1,0 +1,72 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.details.domain.mapper
+
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.Lesson
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.LessonContent
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonContent
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+class LessonUiMapperTest {
+
+    private val mapper = LessonUiMapper()
+
+    @Test
+    fun `map maps lesson to ui screen`() {
+        val lesson = Lesson(
+            lessonTitle = "Lesson title",
+            lessonContent = listOf(
+                LessonContent(
+                    contentId = "1",
+                    contentType = "type",
+                    contentText = "text",
+                    contentImageUrl = "image",
+                    contentAudioUrl = "audio",
+                    contentThumbnailUrl = "thumb",
+                    contentTitle = "title",
+                    contentArtist = "artist",
+                    contentAlbumTitle = "album",
+                    contentGenre = "genre",
+                    contentDescription = "description",
+                    contentReleaseYear = 2024,
+                ),
+            ),
+        )
+
+        val result = mapper.map(lesson)
+
+        val expected = UiLessonScreen(
+            lessonTitle = lesson.lessonTitle,
+            lessonContent = lesson.lessonContent.map {
+                UiLessonContent(
+                    contentId = it.contentId,
+                    contentType = it.contentType,
+                    contentText = it.contentText,
+                    contentImageUrl = it.contentImageUrl,
+                    contentAudioUrl = it.contentAudioUrl,
+                    contentThumbnailUrl = it.contentThumbnailUrl,
+                    contentTitle = it.contentTitle,
+                    contentArtist = it.contentArtist,
+                    contentAlbumTitle = it.contentAlbumTitle,
+                    contentGenre = it.contentGenre,
+                    contentDescription = it.contentDescription,
+                    contentReleaseYear = it.contentReleaseYear,
+                )
+            },
+        )
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `map handles empty content`() {
+        val lesson = Lesson(lessonTitle = "Lesson", lessonContent = emptyList())
+
+        val result = mapper.map(lesson)
+
+        assertEquals(UiLessonScreen(lessonTitle = "Lesson"), result)
+        assertNotNull(result.lessonContent)
+        assertEquals(0, result.lessonContent.size)
+    }
+}

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/usecases/GetLessonUseCaseTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/details/domain/usecases/GetLessonUseCaseTest.kt
@@ -1,10 +1,12 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.details.domain.usecases
 
-import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.ui.UiLessonScreen
+import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.model.Lesson
 import com.d4rk.englishwithlidia.plus.app.lessons.details.domain.repository.LessonRepository
-import io.mockk.coEvery
-import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.fail
@@ -16,28 +18,28 @@ class GetLessonUseCaseTest {
     private val useCase = GetLessonUseCase(repository)
 
     @Test
-    fun `invoke calls repository once`() = runTest {
-        coEvery { repository.getLesson("id") } returns UiLessonScreen()
+    fun `invoke calls repository once`() {
+        every { repository.getLesson("id") } returns flowOf(null)
 
         useCase("id")
 
-        coVerify(exactly = 1) { repository.getLesson("id") }
+        verify(exactly = 1) { repository.getLesson("id") }
     }
 
     @Test
-    fun `invoke returns repository value`() = runTest {
-        val expected = UiLessonScreen(lessonTitle = "title")
-        coEvery { repository.getLesson("id") } returns expected
+    fun `invoke returns repository flow`() = runTest {
+        val expected = Lesson(lessonTitle = "title")
+        every { repository.getLesson("id") } returns flowOf(expected)
 
         val result = useCase("id")
 
-        assertEquals(expected, result)
+        assertEquals(expected, result.single())
     }
 
     @Test
-    fun `invoke propagates exception`() = runTest {
+    fun `invoke propagates exception`() {
         val exception = RuntimeException("error")
-        coEvery { repository.getLesson("id") } throws exception
+        every { repository.getLesson("id") } throws exception
 
         try {
             useCase("id")


### PR DESCRIPTION
## Summary
- introduce dedicated Lesson domain models and a mapper to isolate UI state creation
- update the lesson repository and use case to expose Flow-based domain data with injected JSON parsing
- adjust the lesson view model, DI graph, and unit tests to consume the new flow-based pipeline

## Testing
- `./gradlew test` *(fails: missing Android SDK in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d16b81463c832d88bb50f5c11d134a