### PR TITLE
Fix missing AdsConfig for no data screen

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AdsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/core/di/modules/AdsModule.kt
@@ -43,6 +43,10 @@ val adsModule: Module = module {
         AdsConfig(bannerAdUnitId = AdsConstants.BANNER_AD_UNIT_ID, adSize = AdSize.MEDIUM_RECTANGLE)
     }
 
+    single<AdsConfig>(named(name = "no_data_banner_ad")) {
+        AdsConfig(bannerAdUnitId = AdsConstants.BANNER_AD_UNIT_ID, adSize = AdSize.MEDIUM_RECTANGLE)
+    }
+
     single<AdsConfig>(named(name = "help_large_banner_ad")) {
         AdsConfig(
             bannerAdUnitId = AdsConstants.HELP_LARGE_BANNER_AD_UNIT_ID,


### PR DESCRIPTION
## Summary
- provide a Koin AdsConfig binding for the no data banner so the NoDataScreen can load its ad configuration

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19f00d748832d9bd8586cd6236751