### PR TITLE
Refactor lessons list data layer with SOLID abstractions

### DIFF
--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeRepositoryImpl.kt
@@ -1,44 +1,27 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.list.data
 
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
-import com.d4rk.englishwithlidia.plus.BuildConfig
+import com.d4rk.englishwithlidia.plus.app.lessons.list.data.remote.HomeRemoteDataSource
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.repository.HomeRepository
-import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiHomeResponse
-import com.d4rk.englishwithlidia.plus.core.utils.constants.api.ApiConstants
-import io.ktor.client.HttpClient
-import io.ktor.client.request.get
-import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.serialization.json.Json
 
 class HomeRepositoryImpl(
-    private val client: HttpClient,
     private val dispatchers: DispatcherProvider,
     private val mapper: HomeMapper,
+    private val remoteDataSource: HomeRemoteDataSource,
 ) : HomeRepository {
-
-    private val baseUrl = BuildConfig.DEBUG.let { isDebug ->
-        val environment = if (isDebug) "debug" else "release"
-        "${ApiConstants.BASE_REPOSITORY_URL}/$environment/ro/home/api_get_lessons.json"
-    }
-
-    private val jsonParser = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-    }
 
     override fun getHomeLessons(): Flow<HomeScreen> =
         flow {
-            val jsonString = client.get(baseUrl).bodyAsText()
-            val homeScreen = jsonString.takeUnless { it.isBlank() }
-                ?.let { jsonParser.decodeFromString<ApiHomeResponse>(it) }
+            val response = remoteDataSource.fetchHomeLessons()
+            val homeScreen = response
                 ?.takeIf { it.data.isNotEmpty() }
-                ?.let { mapper.map(it) }
+                ?.let(mapper::map)
                 ?: HomeScreen()
 
             emit(homeScreen)

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/HomeEndpointProvider.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/HomeEndpointProvider.kt
@@ -1,0 +1,37 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.list.data.remote
+
+/**
+ * Provides the url used to retrieve the home lessons payload.
+ */
+interface HomeEndpointProvider {
+    fun lessons(): String
+}
+
+/**
+ * Resolves which backend environment should be used when building endpoints.
+ */
+fun interface HomeEnvironmentResolver {
+    fun environment(): String
+}
+
+/**
+ * Selects the backend environment based on the current build type.
+ */
+class BuildConfigHomeEnvironmentResolver(
+    private val isDebugBuild: Boolean,
+) : HomeEnvironmentResolver {
+    override fun environment(): String = if (isDebugBuild) "debug" else "release"
+}
+
+/**
+ * Default implementation that creates the remote endpoint used for the home screen.
+ */
+class DefaultHomeEndpointProvider(
+    private val baseRepositoryUrl: String,
+    private val environmentResolver: HomeEnvironmentResolver,
+) : HomeEndpointProvider {
+    override fun lessons(): String {
+        val environment = environmentResolver.environment()
+        return "$baseRepositoryUrl/$environment/ro/home/api_get_lessons.json"
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/HomeEndpointProvider.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/HomeEndpointProvider.kt
@@ -3,7 +3,7 @@ package com.d4rk.englishwithlidia.plus.app.lessons.list.data.remote
 /**
  * Provides the url used to retrieve the home lessons payload.
  */
-interface HomeEndpointProvider {
+fun interface HomeEndpointProvider {
     fun lessons(): String
 }
 

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/HomeRemoteDataSource.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/HomeRemoteDataSource.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.Json
 /**
  * Abstraction for fetching the remote home lessons payload.
  */
-interface HomeRemoteDataSource {
+fun interface HomeRemoteDataSource {
     suspend fun fetchHomeLessons(): ApiHomeResponse?
 }
 

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/HomeRemoteDataSource.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/HomeRemoteDataSource.kt
@@ -1,0 +1,31 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.list.data.remote
+
+import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiHomeResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+/**
+ * Abstraction for fetching the remote home lessons payload.
+ */
+interface HomeRemoteDataSource {
+    suspend fun fetchHomeLessons(): ApiHomeResponse?
+}
+
+/**
+ * Ktor backed implementation that downloads and parses the home lessons payload.
+ */
+class KtorHomeRemoteDataSource(
+    private val client: HttpClient,
+    private val endpointProvider: HomeEndpointProvider,
+    private val jsonParser: Json,
+) : HomeRemoteDataSource {
+
+    override suspend fun fetchHomeLessons(): ApiHomeResponse? {
+        val jsonString = client.get(endpointProvider.lessons()).bodyAsText()
+        return jsonString.takeUnless { it.isBlank() }
+            ?.let { jsonParser.decodeFromString<ApiHomeResponse>(it) }
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/englishwithlidia/plus/app/lessons/list/ui/HomeViewModel.kt
@@ -10,6 +10,7 @@ import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.mapper.HomeUiMappe
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.ui.UiHomeScreen
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.usecases.GetHomeLessonsUseCase
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -23,6 +24,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModel(
     private val getHomeLessonsUseCase: GetHomeLessonsUseCase,
     private val uiMapper: HomeUiMapper,

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/data/HomeRepositoryImplTest.kt
@@ -1,13 +1,14 @@
 package com.d4rk.englishwithlidia.plus.app.lessons.list.data
 
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.englishwithlidia.plus.app.lessons.list.data.remote.HomeRemoteDataSource
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeLesson
 import com.d4rk.englishwithlidia.plus.app.lessons.list.domain.model.HomeScreen
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
+import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiHomeLessons
+import com.d4rk.englishwithlidia.plus.core.domain.model.api.ApiHomeResponse
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -15,31 +16,34 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomeRepositoryImplTest {
 
     @Test
-    fun `getHomeLessons emits mapped HomeScreen for valid json`() = runTest {
-        val json = """
-            {
-              "data": [
-                {
-                  "lesson_id": "1",
-                  "lesson_title": "Lesson 1",
-                  "lesson_type": "video",
-                  "lesson_thumbnail_image_url": "url1",
-                  "lesson_deep_link_path": "path1"
-                }
-              ]
-            }
-        """.trimIndent()
-
-        val client = HttpClient(MockEngine { respond(json) })
+    fun `getHomeLessons emits mapped HomeScreen when remote data source returns payload`() = runTest {
         val dispatchers: DispatcherProvider = mockk(relaxed = true) {
             every { io } returns UnconfinedTestDispatcher(testScheduler)
         }
-        val repository = HomeRepositoryImpl(client, dispatchers, HomeMapper())
+        val remoteDataSource = HomeRemoteDataSource {
+            ApiHomeResponse(
+                data = listOf(
+                    ApiHomeLessons(
+                        lessonId = "1",
+                        lessonTitle = "Lesson 1",
+                        lessonType = "video",
+                        lessonThumbnailImageUrl = "url1",
+                        lessonDeepLinkPath = "path1",
+                    )
+                )
+            )
+        }
+        val repository = HomeRepositoryImpl(
+            dispatchers = dispatchers,
+            mapper = HomeMapper(),
+            remoteDataSource = remoteDataSource,
+        )
 
         val result = repository.getHomeLessons().first()
 
@@ -58,12 +62,16 @@ class HomeRepositoryImplTest {
     }
 
     @Test
-    fun `getHomeLessons emits empty HomeScreen for blank response`() = runTest {
-        val client = HttpClient(MockEngine { respond("") })
+    fun `getHomeLessons emits empty HomeScreen when remote returns null`() = runTest {
         val dispatchers: DispatcherProvider = mockk(relaxed = true) {
             every { io } returns UnconfinedTestDispatcher(testScheduler)
         }
-        val repository = HomeRepositoryImpl(client, dispatchers, HomeMapper())
+        val remoteDataSource = HomeRemoteDataSource { null }
+        val repository = HomeRepositoryImpl(
+            dispatchers = dispatchers,
+            mapper = HomeMapper(),
+            remoteDataSource = remoteDataSource,
+        )
 
         val result = repository.getHomeLessons().first()
 
@@ -71,15 +79,40 @@ class HomeRepositoryImplTest {
     }
 
     @Test
-    fun `getHomeLessons emits empty HomeScreen when client throws exception`() = runTest {
-        val client = HttpClient(MockEngine { throw RuntimeException("boom") })
+    fun `getHomeLessons emits empty HomeScreen when remote throws exception`() = runTest {
         val dispatchers: DispatcherProvider = mockk(relaxed = true) {
             every { io } returns UnconfinedTestDispatcher(testScheduler)
         }
-        val repository = HomeRepositoryImpl(client, dispatchers, HomeMapper())
+        val remoteDataSource = HomeRemoteDataSource {
+            throw IllegalStateException("boom")
+        }
+        val repository = HomeRepositoryImpl(
+            dispatchers = dispatchers,
+            mapper = HomeMapper(),
+            remoteDataSource = remoteDataSource,
+        )
 
         val result = repository.getHomeLessons().first()
 
         assertTrue(result.lessons.isEmpty())
+    }
+
+    @Test
+    fun `getHomeLessons propagates cancellation`() = runTest {
+        val dispatchers: DispatcherProvider = mockk(relaxed = true) {
+            every { io } returns UnconfinedTestDispatcher(testScheduler)
+        }
+        val remoteDataSource = HomeRemoteDataSource {
+            throw CancellationException("cancelled")
+        }
+        val repository = HomeRepositoryImpl(
+            dispatchers = dispatchers,
+            mapper = HomeMapper(),
+            remoteDataSource = remoteDataSource,
+        )
+
+        assertThrows<CancellationException> {
+            repository.getHomeLessons().first()
+        }
     }
 }

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/HomeEndpointProviderTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/HomeEndpointProviderTest.kt
@@ -1,0 +1,36 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.list.data.remote
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class HomeEndpointProviderTest {
+
+    @Test
+    fun `BuildConfigHomeEnvironmentResolver returns debug for debug builds`() {
+        val resolver = BuildConfigHomeEnvironmentResolver(isDebugBuild = true)
+
+        assertEquals("debug", resolver.environment())
+    }
+
+    @Test
+    fun `BuildConfigHomeEnvironmentResolver returns release for non debug builds`() {
+        val resolver = BuildConfigHomeEnvironmentResolver(isDebugBuild = false)
+
+        assertEquals("release", resolver.environment())
+    }
+
+    @Test
+    fun `DefaultHomeEndpointProvider builds lessons url using provided environment`() {
+        val baseUrl = "https://example.com"
+        val resolver = HomeEnvironmentResolver { "beta" }
+        val provider = DefaultHomeEndpointProvider(
+            baseRepositoryUrl = baseUrl,
+            environmentResolver = resolver,
+        )
+
+        assertEquals(
+            "https://example.com/beta/ro/home/api_get_lessons.json",
+            provider.lessons(),
+        )
+    }
+}

--- a/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/KtorHomeRemoteDataSourceTest.kt
+++ b/app/src/test/java/com/d4rk/englishwithlidia/plus/app/lessons/list/data/remote/KtorHomeRemoteDataSourceTest.kt
@@ -1,0 +1,86 @@
+package com.d4rk.englishwithlidia.plus.app.lessons.list.data.remote
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class KtorHomeRemoteDataSourceTest {
+
+    private val jsonParser = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    @Test
+    fun `fetchHomeLessons parses json response`() = runTest {
+        val endpoint = "https://example.com/home"
+        val client = HttpClient(MockEngine { request ->
+            assertEquals(endpoint, request.url.toString())
+            respond(
+                content = """
+                    {
+                      "data": [
+                        {
+                          "lesson_id": "1",
+                          "lesson_title": "Lesson 1"
+                        }
+                      ]
+                    }
+                """.trimIndent()
+            )
+        })
+        val dataSource = KtorHomeRemoteDataSource(
+            client = client,
+            endpointProvider = HomeEndpointProvider { endpoint },
+            jsonParser = jsonParser,
+        )
+
+        val response = dataSource.fetchHomeLessons()
+
+        requireNotNull(response)
+        assertEquals(1, response.data.size)
+        assertEquals("1", response.data.first().lessonId)
+        assertEquals("Lesson 1", response.data.first().lessonTitle)
+    }
+
+    @Test
+    fun `fetchHomeLessons returns null for blank response`() = runTest {
+        val endpoint = "https://example.com/home"
+        val client = HttpClient(MockEngine { respond("") })
+        val dataSource = KtorHomeRemoteDataSource(
+            client = client,
+            endpointProvider = HomeEndpointProvider { endpoint },
+            jsonParser = jsonParser,
+        )
+
+        val response = dataSource.fetchHomeLessons()
+
+        assertNull(response)
+    }
+
+    @Test
+    fun `fetchHomeLessons propagates network errors`() = runTest {
+        val endpoint = "https://example.com/home"
+        val client = HttpClient(MockEngine { throw IllegalStateException("boom") })
+        val dataSource = KtorHomeRemoteDataSource(
+            client = client,
+            endpointProvider = HomeEndpointProvider { endpoint },
+            jsonParser = jsonParser,
+        )
+
+        try {
+            dataSource.fetchHomeLessons()
+            fail("Expected exception to be thrown")
+        } catch (expected: IllegalStateException) {
+            assertEquals("boom", expected.message)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce dedicated endpoint provider and remote data source for the lessons list to better enforce SOLID responsibilities
- refactor the repository and dependency graph to rely on the new abstractions while keeping cancellation handling intact
- expand unit coverage for the repository and add targeted tests for the endpoint provider and Ktor data source

## Testing
- ./gradlew test *(fails: Android SDK not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1da4d1ad0832dbd1eec233f9042f6